### PR TITLE
Cartes/Vidéos : résolution de deux bugs d'affichage

### DIFF
--- a/content_manager/templates/content_manager/blocks/card_vertical.html
+++ b/content_manager/templates/content_manager/blocks/card_vertical.html
@@ -6,7 +6,7 @@
       <{{ value.heading_tag | default:"h3" }} class="fr-card__title">
         {% if value.link and value.link.url %}
           <a href="{{ value.link.url }}" {% if value.link.url.0 != '/' and request.get_host not in value.link.url %}target="_blank" rel="noopener noreferrer"{% endif %}>
-            {{ value.title }} {{value.link.url}}
+            {{ value.title }}
             {% if value.link.url.0 != '/' and request.get_host not in value.link.url %}
             <span class="fr-sr-only">{% translate "Opens a new window" %}</span>
             {% endif %}

--- a/content_manager/templates/content_manager/blocks/video.html
+++ b/content_manager/templates/content_manager/blocks/video.html
@@ -9,7 +9,7 @@
     {{ value.caption }}
     <a class="fr-link" href="{{ value.caption }}">{% translate "Watch on the site" %}</a>
   </figcaption>
-  {% if value.transcription %}
+  {% if value.transcription.content %}
     {% include_block value.transcription %}
   {% endif %}
 </figure>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "content-manager"
-version = "1.5.0"
+version = "1.5.1"
 description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l'État, accessible et responsive"
 authors = [
   "Sébastien Reuiller <sebastien.reuiller@beta.gouv.fr>",


### PR DESCRIPTION
## 🎯 Objectif
Deux bugs ont été relevés après la publication de la version 1.5.0 :
- Les cartes verticales affichent l'URL du lien externe dans le titre
- Les vidéos incluent le module transcription même s'il n'y en a pas
 
## 🔍 Implémentation
- [x] Retrait de l'URL en trop dans le composant Carte verticale
- [x] Vérification que le contenu de la transcription existe avant de l'inclure.
