### PR TITLE
Bloc Liste des sous-pages : ne montrer que les sous-pages publiées

### DIFF
--- a/content_manager/templates/content_manager/blocks/subpages_list.html
+++ b/content_manager/templates/content_manager/blocks/subpages_list.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 <ul>
-  {% for subpage in page.get_children.all|dictsort:"title" %}
+  {% for subpage in page.get_children.live.all|dictsort:"title" %}
     <li>
       <a href="{% pageurl subpage %}">{{ subpage.title }}</a>
     </li>


### PR DESCRIPTION
## 🎯 Objectif
Le bloc Liste des sous pages génère des liens pour les sous-pages non publiées, qui pointent donc sur des erreurs 404.

## 🔍 Implémentation
- [x] Filtrage du queryset dans le template