### PR TITLE
[Buxfix] Résolution d’une erreur 400 dans les prévisualisations

### DIFF
--- a/content_manager/management/commands/set_config.py
+++ b/content_manager/management/commands/set_config.py
@@ -10,9 +10,19 @@ from content_manager.models import CmsDsfrConfig
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        """Sets the site hostname, and imports contents from the config.json file if present"""
+        """
+        Sets the site hostname and site_name,
+        and imports contents from the config.json file if present.
+        """
+        if "http://" in settings.HOST_URL or "https://" in settings.HOST_URL:
+            raise ValueError(
+                """The HOST_URL environment variable must contain the domain name only,
+                without the port or http/https protocol."""
+            )
+
         site = Site.objects.filter(is_default_site=True).first()
         site.hostname = settings.HOST_URL
+        site.site_name = settings.WAGTAIL_SITE_NAME
         site.save()
 
         if isfile("config.json"):


### PR DESCRIPTION
## 🎯 Objectif
Un utilisateur avait des erreurs 400 dans les prévisualisations, après investigation, le champ `hostname` contenait l'URL complète et le champ `site_name` était vide : modification pour s'assurer que ni l’un ni l’autre n’arrive

## 🔍 Implémentation
Modifications de la commande `set_config` :

- [x] Ajout d’un message d'erreur si la variable d’environnement `HOST_URL` contient "http" ou "https://"
- [x] Ajout du nom du site, récupéré depuis la configuration, à l'objet `Site`.