### PR TITLE
Mises à jour du Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --no-root
+          snap install ruff
       - name: 📄 Copy empty .env.test to .env
         run: |
           cp .env.test .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --no-root
-          snap install ruff
       - name: 📄 Copy empty .env.test to .env
         run: |
           cp .env.test .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
+          pip install ruff
           poetry install --no-root
       - name: 📄 Copy empty .env.test to .env
         run: |
           cp .env.test .env
-      - name: ✨ Black
+      - name: ✨ Black & ruff
         run: |
           make quality
       - name: 🚧 Check pending migrations # continue-on-error: true

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,0 @@
-name: Ruff
-on: [push, pull_request]
-jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ quality:
 
 .PHONY: fix
 fix:
-	$(EXEC_CMD) ruff check .  --fix
+	$(EXEC_CMD) ruff check . --fix
 	$(EXEC_CMD) poetry run black --exclude=venv .
 
 .PHONY: index

--- a/Makefile
+++ b/Makefile
@@ -46,19 +46,8 @@ fix:
 index:
 	poetry run python manage.py update_index
 
-.PHONY: init-dev
-init-dev:
-	$(EXEC_CMD) poetry install
-	$(EXEC_CMD) poetry run pre-commit install
-	$(EXEC_CMD) poetry run python manage.py migrate
-	make collectstatic
-	$(EXEC_CMD) poetry run python manage.py set_config
-	$(EXEC_CMD) poetry run python manage.py import_dsfr_pictograms
-	$(EXEC_CMD) poetry run python manage.py create_starter_pages
-	make index
-
-.PHONY: init-prod
-init-dev:
+.PHONY: init
+init:
 	$(EXEC_CMD) poetry install --without dev
 	$(EXEC_CMD) poetry run python manage.py migrate
 	make collectstatic
@@ -66,6 +55,13 @@ init-dev:
 	$(EXEC_CMD) poetry run python manage.py import_dsfr_pictograms
 	$(EXEC_CMD) poetry run python manage.py create_starter_pages
 	make index
+
+.PHONY: init-dev
+init-dev:
+	make init
+	$(EXEC_CMD) poetry install
+	$(EXEC_CMD) poetry run pre-commit install
+
 
 .PHONY: update
 init:

--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,20 @@ sass:
 
 .PHONY: quality
 quality:
+	$(EXEC_CMD) ruff check .
 	$(EXEC_CMD) poetry run black --check --exclude=venv .
 
 .PHONY: fix
 fix:
+	$(EXEC_CMD) ruff check .  --fix
 	$(EXEC_CMD) poetry run black --exclude=venv .
-	$(EXEC_CMD) poetry run isort --skip-glob="**/migrations" --extend-skip-glob="venv" .
 
+.PHONY: index
+index:
+	poetry run python manage.py update_index
 
-.PHONY: init
-init:
+.PHONY: init-dev
+init-dev:
 	$(EXEC_CMD) poetry install
 	$(EXEC_CMD) poetry run pre-commit install
 	$(EXEC_CMD) poetry run python manage.py migrate
@@ -51,6 +55,25 @@ init:
 	$(EXEC_CMD) poetry run python manage.py set_config
 	$(EXEC_CMD) poetry run python manage.py import_dsfr_pictograms
 	$(EXEC_CMD) poetry run python manage.py create_starter_pages
+	make index
+
+.PHONY: init-prod
+init-dev:
+	$(EXEC_CMD) poetry install --without dev
+	$(EXEC_CMD) poetry run python manage.py migrate
+	make collectstatic
+	$(EXEC_CMD) poetry run python manage.py set_config
+	$(EXEC_CMD) poetry run python manage.py import_dsfr_pictograms
+	$(EXEC_CMD) poetry run python manage.py create_starter_pages
+	make index
+
+.PHONY: update
+init:
+	$(EXEC_CMD) poetry install --without dev
+	$(EXEC_CMD) poetry run python manage.py migrate
+	make collectstatic
+	make index
+
 
 .PHONY: demo
 demo:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1831,6 +1831,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.4.10"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.4.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c2c4d0859305ac5a16310eec40e4e9a9dec5dcdfbe92697acd99624e8638dac"},
+    {file = "ruff-0.4.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a79489607d1495685cdd911a323a35871abfb7a95d4f98fc6f85e799227ac46e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1dd1681dfa90a41b8376a61af05cc4dc5ff32c8f14f5fe20dba9ff5deb80cd6"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c75c53bb79d71310dc79fb69eb4902fba804a81f374bc86a9b117a8d077a1784"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18238c80ee3d9100d3535d8eb15a59c4a0753b45cc55f8bf38f38d6a597b9739"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d8f71885bce242da344989cae08e263de29752f094233f932d4f5cfb4ef36a81"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:330421543bd3222cdfec481e8ff3460e8702ed1e58b494cf9d9e4bf90db52b9d"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e9b6fb3a37b772628415b00c4fc892f97954275394ed611056a4b8a2631365e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f54c481b39a762d48f64d97351048e842861c6662d63ec599f67d515cb417f6"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:67fe086b433b965c22de0b4259ddfe6fa541c95bf418499bedb9ad5fb8d1c631"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:acfaaab59543382085f9eb51f8e87bac26bf96b164839955f244d07125a982ef"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3cea07079962b2941244191569cf3a05541477286f5cafea638cd3aa94b56815"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:338a64ef0748f8c3a80d7f05785930f7965d71ca260904a9321d13be24b79695"},
+    {file = "ruff-0.4.10-py3-none-win32.whl", hash = "sha256:ffe3cd2f89cb54561c62e5fa20e8f182c0a444934bf430515a4b422f1ab7b7ca"},
+    {file = "ruff-0.4.10-py3-none-win_amd64.whl", hash = "sha256:67f67cef43c55ffc8cc59e8e0b97e9e60b4837c8f21e8ab5ffd5d66e196e25f7"},
+    {file = "ruff-0.4.10-py3-none-win_arm64.whl", hash = "sha256:dd1fcee327c20addac7916ca4e2653fbbf2e8388d8a6477ce5b4e986b68ae6c0"},
+    {file = "ruff-0.4.10.tar.gz", hash = "sha256:3aa4f2bc388a30d346c56524f7cacca85945ba124945fe489952aadb6b5cd804"},
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.10.1"
 description = "An Amazon S3 Transfer Manager"
@@ -2212,4 +2238,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "260be4cf316b20fb952a0fb60901abe8e06ec77492ceb36a63e1302f71f010e1"
+content-hash = "0062e5a625eec235ed0c74e04ea0c059bb6de669857995c5ee1925dfa38d4aa2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ libsass = "^0.22.0"
 django-compressor = "^4.4"
 faker = "^24.3.0"
 django-debug-toolbar = "^4.4.2"
+ruff = "^0.4.10"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## 🎯 Objectif
Ajouter une commande `make update` pour les mises à jour non faites via Scalingo. En profiter pour faire du nettoyage dans le `Makefile` en général.

## 🔍 Implémentation
- [x] Séparation de certaines commandes de `make init` en `make init-dev`
- [x] Ajout d’une commande `make update`
- [x] Ajout d’une commande `make index`
- [x] Ajout de `ruff` au `pyproject.toml`
- [x] Modification de `make quality`, `make fix` et de la CI pour prendre en compte `ruff`
