### PR TITLE
Correction du bouton

### DIFF
--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -74,9 +74,24 @@
   {% endif %}
 {% endblock header_search %}
 
-{# Leave burger_menu and main_menu blocks empty if the main menu is not used #}
-{# block burger_menu #}
-{# endblock burger_menu #}
+{% block burger_menu %}
+  {% translate "Search" as search_label %}
+  <div class="fr-header__navbar">
+    {% if settings.content_manager.CmsDsfrConfig.search_bar %}
+      <button class="fr-btn--search fr-btn"
+              data-fr-opened="false"
+              aria-controls="modal-search"
+              id="fr-btn-search-mobile"
+              title="{{ search_label }}">{{ search_label }}</button>
+    {% endif %}
+    {% translate "Menu" as menu_label %}
+    <button class="fr-btn--menu fr-btn"
+            data-fr-opened="false"
+            aria-controls="fr-menu-mobile"
+            id="fr-btn-menu-mobile"
+            title="{{ menu_label }}">{{ menu_label }}</button>
+  </div>
+{% endblock burger_menu %}
 
 {% block main_menu %}
   <div class="fr-header__menu fr-modal"


### PR DESCRIPTION
## 🎯 Objectif
Des utilisateurs signalent que même après #165, le problème subsiste.

## 🔍 Implémentation
- [x] Mise en place du menu mobile en local plutôt qu'utiliser celui par défaut de `django-dsfr`
- [x] Ajout au passage du bouton mobile vers le champ de recherche si l’option est activée.

## 🖼️ Images

### Boutons d’en-tête sur mobile
![Capture d’écran du 2024-06-25 16-05-07](https://github.com/numerique-gouv/sites-faciles/assets/765956/03e6326b-0dae-43a5-ae51-ff19788e1726)

### Effet après clic sur le bouton de recherche
![Capture d’écran du 2024-06-25 16-05-11](https://github.com/numerique-gouv/sites-faciles/assets/765956/8b070834-50c8-44a5-bb7c-8121ac3aa754)

### Effet après clic sur le bouton burger
![Capture d’écran du 2024-06-25 16-05-17](https://github.com/numerique-gouv/sites-faciles/assets/765956/320804da-d1a6-406d-8f3e-ab29898117c9)
