### PR TITLE
Force le thème clair à la première visite si le sélecteur de thème est désactivé

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,9 +2,8 @@
 {% get_settings %}
 <!DOCTYPE html>
 <html lang="{% get_current_language as LANGUAGE_CODE %}{{ LANGUAGE_CODE }}"
-      data-fr-scheme="system"
+      {% if settings.content_manager.CmsDsfrConfig.theme_modale_button %} data-fr-scheme="system" {% else %} data-fr-scheme="light" {% endif %}
       {% if settings.content_manager.CmsDsfrConfig.mourning %}data-fr-mourning{% endif %}>
-
   <head>
     <meta charset="utf-8" />
     <meta name="viewport"


### PR DESCRIPTION
## 🎯 Objectif
Fix #171

## 🔍 Implémentation
- [x] Si le sélecteur de thème est désactivé, c'est le thème clair qui est activé par défaut, et non système.

## ⚠️ Informations supplémentaires
Limite : cela ne marche qu'à la première visite. Si le site a déjà été visité, la préférence est enregistrée dans les cookies et il faut donc les vider pour que ça marche.
