### PR TITLE
[Bugfix] Répare l'affichage des tuiles

### DIFF
--- a/content_manager/templates/content_manager/blocks/tile.html
+++ b/content_manager/templates/content_manager/blocks/tile.html
@@ -34,7 +34,7 @@
       {% endif %}
     </div>
   </div>
-  {% if pictogram %}
+  {% if value.image %}
     <div class="fr-tile__header">
       {% image value.image original as pictogram %}
 


### PR DESCRIPTION
## 🎯 Objectif
- Les pictogrammes ne s'affichent plus sur les tuiles.
- Si un lien est inséré dans la description d’une tuile, il prend le pas sur le lien de la tuile.

## 🔍 Implémentation
- [x] Correction de l'affichage des pictogrammes
- [x] Suppression de la possibilité d’ajouter des liens dans la description d’une tuile.

## 🖼️ Images
![Capture d’écran du 2024-07-01 16-53-40](https://github.com/numerique-gouv/sites-faciles/assets/765956/d81b7f92-2a03-4f76-b3a0-30d5f7e8f135)
