### PR TITLE
Ajout des listes de boutons aux appels à action

### DIFF
--- a/content_manager/templates/content_manager/widgets/dsfr-icon-picker-widget.html
+++ b/content_manager/templates/content_manager/widgets/dsfr-icon-picker-widget.html
@@ -1,9 +1,13 @@
-{% load static %}
+{% load static i18n %}
 <div class="icon-picker-widget">
-  {% include "django/forms/widgets/text.html" %}
+  <div style="display: none;">{% include "django/forms/widgets/text.html" %}</div>
 
   {% with widget.attrs.id as widget_id %}
-    <span id="{{ widget_id }}-icon" aria-hidden="true"></span>
+    <button id="{{ widget_id }}-button"
+            class="button bicolor button--icon button-secondary"
+            type="button">
+      <span id="{{ widget_id }}-icon" class="icon-wrapper"></span>{% translate "Select icon" %}
+    </button>
     <script>
       (async () => {
         let widgetInput = document.getElementById('{{ widget_id }}');
@@ -17,8 +21,8 @@
               widgetInput.value = jsonIconData.iconClass;
               widgetIcon.classList.add(jsonIconData.iconClass, "fr-icon--lg", "fr-mt-1w");
             } else {
-              widgetInput.innerHTML = "";
-              widgetIcon.className = "";
+              widgetInput.value = "";
+              widgetIcon.className = "icon-wrapper";
             }
           },
           onReset: function () {
@@ -27,8 +31,23 @@
           }
         }
 
-        let _uip = new UniversalIconPicker('#{{ widget_id }}', options);
+        let _uip = new UniversalIconPicker('#{{ widget_id }}-button', options);
       })();
+    </script>
+    <script defer>
+        window.addEventListener('DOMContentLoaded', function() {
+          // Set the icon on page load if any
+          let widgetInput = document.getElementById('{{ widget_id }}');
+          let widgetIcon = document.getElementById('{{ widget_id }}-icon');
+
+          if (widgetInput.value) {
+          widgetIcon.classList.add(widgetInput.value, "fr-icon--lg", "fr-mt-1w");
+          console.log("value updated: " + widgetIcon.classList)
+          } else {
+          console.log("no value")
+          }
+        }, false);
+
     </script>
   {% endwith %}
 </div>


### PR DESCRIPTION
## 🎯 Objectif
Il faut permettre de mettre plusieurs boutons aux appels à action, que ce soit ceux dans l'en-tête ou dans les streamfields.
On doit pouvoir utiliser des boutons primaires ou secondaires, et y ajouter des icônes.

## 🔍 Implémentation
- [ ] Ajout du champ Button list au bloc TextAndCTA
- [ ] Ajout du champ Button list à l'en-tête
- [x] Ajout du sélecteur d’icônes au composant Bouton

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
