### PR TITLE
Masque le header des cartes horizontales si pas d'image

### DIFF
--- a/content_manager/templates/content_manager/blocks/card_horizontal.html
+++ b/content_manager/templates/content_manager/blocks/card_horizontal.html
@@ -58,8 +58,8 @@
     {% endif %}
 
   </div>
-  <div class="fr-card__header">
-    {% if value.image %}
+  {% if value.image %}
+    <div class="fr-card__header">
       <div class="fr-card__img">{% image value.image width-1200 class="fr-responsive-img" alt="" %}</div>
       {% if value.image_badge %}
         <ul class="fr-badges-group">
@@ -68,6 +68,6 @@
           {% endfor %}
         </ul>
       {% endif %}
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
## 🎯 Objectif

Si on créer une carte horizontale sans image on a un espace blanc
<img width="1246" alt="Capture d’écran 2024-08-09 à 15 13 34" src="https://github.com/user-attachments/assets/9cd771ae-5eb2-44a1-b8ab-1d0e7cf2f97e">


## 🔍 Implémentation

Change la condition de ligne pour masquer le header
<img width="1230" alt="Capture d’écran 2024-08-09 à 15 14 28" src="https://github.com/user-attachments/assets/625e6633-fdf2-4567-8e38-726cc74a69c3">

