### PR TITLE
Éditeur de texte riche : force l'affichage des <li> avec des disques comme c'est le cas dans le DSFR

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -17,3 +17,11 @@
 .admin-hidden {
     display: none;
 }
+
+/*** Changes to the editor to style it closer than the DSFR ***/
+
+/* Force li at all indent levels to have discs */
+.public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1,
+.public-DraftStyleDefault-unorderedListItem {
+    list-style-type: disc !important;
+}


### PR DESCRIPTION
## 🎯 Objectif
Les puces apparaissent différemment dans le site (où elles sont régies par le DSFR) que dans l'éditeur de texte riche (où elles sont régies par Draftail) : il faut unifier tout ça.

## 🔍 Implémentation
- [x] Ajout d'une règle CSS

## 🖼️ Images
### Éditeur : avant
![Capture d’écran du 2024-08-28 17-46-15](https://github.com/user-attachments/assets/6bff90d6-0a6c-44d8-b853-48871650c74a)

### Éditeur : après
![Capture d’écran du 2024-08-28 17-46-26](https://github.com/user-attachments/assets/cfff0970-3676-4470-9412-842045633838)

### Rendu
![Capture d’écran du 2024-08-28 17-46-40](https://github.com/user-attachments/assets/d7f1bca6-359e-4e6c-b4c8-36a150990316)
