### PR TITLE
Ajout des blocs accordéons et étapier au multi-colonnes et au fonds pleine largeur

### DIFF
--- a/content_manager/blocks.py
+++ b/content_manager/blocks.py
@@ -423,6 +423,9 @@ class AccordionsBlock(blocks.StreamBlock):
     title = blocks.CharBlock(label=_("Title"))
     accordion = AccordionBlock(label=_("Accordion"), min_num=1, max_num=15)
 
+    class Meta:
+        template = "content_manager/blocks/accordions.html"
+
 
 class AlertBlock(blocks.StructBlock):
     title = blocks.CharBlock(label=_("Message title"), required=False)
@@ -626,6 +629,9 @@ class StepperBlock(blocks.StructBlock):
     total = blocks.IntegerBlock(label=_("Number of steps"))
     current = blocks.IntegerBlock(label=_("Current step"))
     steps = StepsListBlock(label=_("Steps"))
+
+    class Meta:
+        template = "content_manager/blocks/stepper.html"
 
 
 class TextAndCTA(blocks.StructBlock):
@@ -843,9 +849,11 @@ class CommonStreamBlock(blocks.StreamBlock):
     image = ImageBlock(label=_("Image"))
     video = VideoBlock(label=_("Video"))
     transcription = TranscriptionBlock(label=_("Transcription"))
+    accordions = AccordionsBlock(label=_("Accordions"), group=_("DSFR components"))
     callout = CalloutBlock(label=_("Callout"), group=_("DSFR components"))
     highlight = HighlightBlock(label=_("Highlight"), group=_("DSFR components"))
     quote = QuoteBlock(label=_("Quote"), group=_("DSFR components"))
+    stepper = StepperBlock(label=_("Stepper"), group=_("DSFR components"))
     text_cta = TextAndCTA(label=_("Text and call to action"))
     link = SingleLinkBlock(label=_("Single link"))
     iframe = IframeBlock(label=_("Iframe"), group=_("DSFR components"))

--- a/content_manager/templates/content_manager/blocks/accordions.html
+++ b/content_manager/templates/content_manager/blocks/accordions.html
@@ -2,18 +2,18 @@
 <div class="fr-container fr-py-3w">
   <div class="fr-grid-row fr-grid-row--gutters">
     <div class="fr-col-12 fr-col-offset-md-2 fr-col-md-8">
-      {% for subblock in block.value %}
-        {% if subblock.block_type == 'title' %}
+      {% for subblock in value %}
+        {% if subblock.block_type == "title" %}
           <div class="fr-col-12">
             <h2>{{ subblock.value }}</h2>
           </div>
         {% endif %}
       {% endfor %}
       <div class="fr-accordions-group">
-        {% for subblock in block.value %}
-          {% if subblock.block_type == 'accordion' %}
+        {% for subblock in value %}
+          {% if subblock.block_type == "accordion" %}
             {% with forloop.counter0|lower as str_counter %}
-              {% with "accordion-"|add:accordions_id|add:"-"|add:str_counter as accordion_id %}
+              {% with "accordion-"|add:subblock.id|add:"-"|add:str_counter as accordion_id %}
                 {% dsfr_accordion id=accordion_id title=subblock.value.title content=subblock.value.content|richtext %}
               {% endwith %}
             {% endwith %}

--- a/content_manager/templates/content_manager/blocks/blocks_stream.html
+++ b/content_manager/templates/content_manager/blocks/blocks_stream.html
@@ -23,10 +23,6 @@
     <div class="fr-container fr-mb-4w">{% include_block block %}</div>
   {% elif block.block_type == "tile" %}
     <div class="fr-container fr-mb-4w">{% include_block block %}</div>
-  {% elif block.block_type == "accordions" %}
-    {% include "content_manager/blocks/accordions.html" with accordions_id=forloop.counter0|lower %}
-  {% elif block.block_type == "stepper" %}
-    {% include "content_manager/blocks/stepper.html" %}
   {% elif block.block_type == "separator" %}
     <div class="fr-container">
       <hr class="fr-mt-{{ block.value.top_margin }}w fr-mb-{{ block.value.bottom_margin }}w fr-py-1v">

--- a/content_manager/templates/content_manager/blocks/multicolumns.html
+++ b/content_manager/templates/content_manager/blocks/multicolumns.html
@@ -15,13 +15,13 @@
     {% endif %}
     <div class="fr-grid-row fr-grid-row--gutters fr-py-3w">
       {% for subblock in value.columns %}
-        {% if subblock.block_type == 'column' %}
+        {% if subblock.block_type == "column" %}
           <div class="fr-col-12{% if subblock.value.width %} fr-col-lg-{{ subblock.value.width }}{% endif %}">
             {% include_block subblock.value.content %}
           </div>
-        {% elif subblock.block_type == 'text' %}
+        {% elif subblock.block_type == "text" %}
           <div class="fr-col-12 fr-col-sm">{{ subblock.value|richtext }}</div>
-        {% elif subblock.block_type == 'video' %}
+        {% elif subblock.block_type == "video" %}
           <div class="fr-col-12 fr-col-sm">
             <h2>{{ subblock.value.title }}</h2>
             {% include_block subblock %}

--- a/content_manager/templates/content_manager/blocks/stepper.html
+++ b/content_manager/templates/content_manager/blocks/stepper.html
@@ -1,19 +1,18 @@
 <div class="fr-container fr-my-3w">
-    <div class="fr-stepper">
-        <h2 class="fr-stepper__title">{{ block.value.title }}</h2>
-        <div class="fr-stepper__steps"
-             data-fr-current-step="{{ block.value.current }}"
-             data-fr-steps="{{ block.value.total }}">
+  <div class="fr-stepper">
+    <h2 class="fr-stepper__title">{{ value.title }}</h2>
+    <div class="fr-stepper__steps"
+         data-fr-current-step="{{ value.current }}"
+         data-fr-steps="{{ value.total }}"></div>
+    <div class="fr-grid-row fr-grid-row--gutters">
+      {% for step in value.steps %}
+        <div class="fr-col-12 fr-col-sm">
+          <p>
+            <strong>{{ step.value.title }}</strong>
+          </p>
+          <p>{{ step.value.detail|linebreaksbr }}</p>
         </div>
-        <div class="fr-grid-row fr-grid-row--gutters">
-            {% for subblock in block.value.steps %}
-                <div class="fr-col-12 fr-col-sm">
-                    <p>
-                        <strong>{{ subblock.value.title }}</strong>
-                    </p>
-                    <p>{{ subblock.value.detail|linebreaksbr }}</p>
-                </div>
-            {% endfor %}
-        </div>
+      {% endfor %}
     </div>
+  </div>
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "content-manager"
-version = "1.8.0"
-description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l'État, accessible et responsive"
+version = "1.9.0"
+description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l’État, accessible et responsive"
 authors = [
   "Sébastien Reuiller <sebastien.reuiller@beta.gouv.fr>",
   "Sylvain Boissel <sylvain.boissel@beta.gouv.fr>",


### PR DESCRIPTION
## 🎯 Objectif
Les blocs "Accordéons" et "Étapier" ne sont pour l'instant disponibles que dans le flux principal, il faut pouvoir les ajouter dans les autres.

## 🔍 Implémentation
- [X] Ajout du bloc Accordéons au multi-colonnes et au fonds pleine largeur
- [X] Ajout du bloc Étapier au multi-colonnes et au fonds pleine largeur

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue
- [x] Ajout d’une validation du nombre minimum (1) et maximum (8) d'étapes dans le bloc Étapier

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
