### PR TITLE
Compatibilité avec Scalingo

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export PYTHONPATH=/build/${REQUEST_ID}/.apt/usr/lib/python3/dist-packages/:${PYTHONPATH}
+
+# collect static
+python manage.py collectstatic --noinput

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -3,4 +3,4 @@
 export PYTHONPATH=/build/${REQUEST_ID}/.apt/usr/lib/python3/dist-packages/:${PYTHONPATH}
 
 # collect static
-python manage.py collectstatic --noinput
+python manage.py collectstatic --no-input --ignore=*.sass


### PR DESCRIPTION
## 🎯 Objectif

Simplifier le déploiement et la mise à jour vers Scalingo.

## 🔍 Implémentation

Simplement suivi les instructions de https://doc.scalingo.com/languages/python/django/start#collect-static en ajoutant un script qui invoque `collectstatic`.