### PR TITLE
[Bugfix] Augmentation de la limite de champs autorisés pour résoudre les erreurs 400 à la sauvegarde

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -316,6 +316,9 @@ WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES = (
 
 WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg"]
 
+# Allows for complex Streamfields without completely removing checks
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+
 # Email settings
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "")
 


### PR DESCRIPTION
## 🎯 Objectif
Fix #225 : le problème est dû au fait que les Streamfield complexes avec un grand nombre de blocs peuvent dépasser la limite de champs autorisés dans les POSTs HTML, causant l'erreur `The number of GET/POST parameters exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS` (masquée en production par une erreur 400)

## 🔍 Implémentation
- [x] Augmentation de la limite de nombre de champs autorisés dans les posts (cf. [documentation de Django](https://docs.djangoproject.com/en/5.1/ref/settings/#data-upload-max-number-fields))

## ⚠️ Informations supplémentaires
- [x] Création de https://github.com/wagtail/wagtail/issues/12452 pour demander d'afficher un message d'erreur à l'utilisateur plutôt qu'une erreur 400.
