### PR TITLE
[Bugfix] Correction des pictogrammes dans les tuiles en mode sombre

### DIFF
--- a/content_manager/templates/content_manager/blocks/image_and_text.html
+++ b/content_manager/templates/content_manager/blocks/image_and_text.html
@@ -3,7 +3,9 @@
   <div class="fr-grid-row fr-grid-row--gutters">
     {% if value.image_side == "left" %}
       <div class="fr-col-12 fr-col-sm-{{ value.image_ratio }}">
-        <div class="bordered fr-px-2w">{% image value.image original class="fr-responsive-img" alt="" %}</div>
+        <div class="bordered fr-px-2w">
+          {% include "content_manager/blocks/image_svg_or_raster.html" with extra_classes="fr-responsive-img" alt="" %}
+        </div>
       </div>
       <div class="fr-col-12 fr-col-sm{{ -12|add:value.image_ratio }}">
         {{ value.text|richtext }}
@@ -33,7 +35,9 @@
         {% endif %}
       </div>
       <div class="fr-col-12 fr-col-sm-{{ value.image_ratio }}">
-        <div class="bordered fr-px-2w">{% image value.image original class="fr-responsive-img" alt="" %}</div>
+        <div class="bordered fr-px-2w">
+          {% include "content_manager/blocks/image_svg_or_raster.html" with extra_classes="fr-responsive-img" alt="" %}
+        </div>
       </div>
     {% endif %}
   </div>

--- a/content_manager/templates/content_manager/blocks/image_svg_or_raster.html
+++ b/content_manager/templates/content_manager/blocks/image_svg_or_raster.html
@@ -1,0 +1,15 @@
+{% load wagtailimages_tags %}
+
+{% image value.image original as artwork %}
+
+{% if artwork.file.name|slice:"-4:" == ".svg" %}
+  <div class="fr-responsive-img">
+    <svg aria-hidden="true" class="fr-artwork" viewBox="0 0 80 80">
+      <use class="fr-artwork-decorative" href="{{ artwork.full_url }}#artwork-decorative"></use>
+      <use class="fr-artwork-minor" href="{{ artwork.full_url }}#artwork-minor"></use>
+      <use class="fr-artwork-major" href="{{ artwork.full_url }}#artwork-major"></use>
+    </svg>
+  </div>
+{% else %}
+  {% image value.image original class=extra_classes alt=alt %}
+{% endif %}

--- a/content_manager/templates/content_manager/blocks/tile.html
+++ b/content_manager/templates/content_manager/blocks/tile.html
@@ -38,7 +38,7 @@
     <div class="fr-tile__header">
       {% image value.image original as pictogram %}
 
-      {% if pictogram.url|slice:"-4:" == ".svg" %}
+      {% if pictogram.file.name|slice:"-4:" == ".svg" %}
         <div class="fr-tile__pictogram">
           <svg aria-hidden="true"
                class="fr-artwork"


### PR DESCRIPTION
## 🎯 Objectif
Les pictogrammes dans les tuiles sont supposés s'afficher correctement en mode sombre. Ce n'était pas le cas sur les S3 car l'URL est remplacée par

## 🔍 Implémentation
- [x] Remplacement de l'URL complète par le nom du fichier dans une condition
- [x] Gestion similaire pour les blocs "image et texte"

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images
![Capture d’écran du 2024-10-30 17-28-49](https://github.com/user-attachments/assets/0206a415-8412-4098-b639-f9125cd73580)
![Capture d’écran du 2024-10-30 17-28-40](https://github.com/user-attachments/assets/23029fb1-07dc-4998-aae9-501d3755b2b3)
