### PR TITLE
[Bugfix] Mise à jour des pictogrammes lors des mises à jour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,9 @@ init-dev:
 update:
 	$(EXEC_CMD) poetry install --without dev
 	$(EXEC_CMD) poetry run python manage.py migrate
-	$(EXEC_CMD) poetry run python manage.py import_page_templates
 	make collectstatic
+	$(EXEC_CMD) poetry run python manage.py import_dsfr_pictograms
+	$(EXEC_CMD) poetry run python manage.py import_page_templates
 	make index
 
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-postdeploy: python manage.py migrate && python manage.py import_page_templates && python manage.py update_index
+postdeploy: python manage.py migrate && python manage.py import_dsfr_pictograms && python manage.py import_page_templates && python manage.py update_index
 web: gunicorn config.wsgi --log-file -

--- a/content_manager/management/commands/import_dsfr_pictograms.py
+++ b/content_manager/management/commands/import_dsfr_pictograms.py
@@ -1,6 +1,5 @@
 import os
 
-from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from wagtail.images.models import Image
 
@@ -9,15 +8,13 @@ from content_manager.utils import import_image
 
 
 class Command(BaseCommand):
-    help = """Import all the pictograms from the DSFR"""
+    help = """
+    Import all the pictograms from the DSFR.
+
+    Should only be launched if the statics have been collected at least once.
+    """
 
     def handle(self, *args, **kwargs):
-        call_command(
-            "collectstatic",
-            "--ignore=*.sass",
-            interactive=False,
-        )
-
         picto_root = "staticfiles/dsfr/dist/artwork/pictograms/"
         picto_folders = os.listdir(picto_root)
         picto_folders.sort()

--- a/content_manager/tests/test_blocks.py
+++ b/content_manager/tests/test_blocks.py
@@ -322,6 +322,30 @@ class TileBlockTestCase(WagtailPageTestCase):
 
         self.assertContains(response, "fr-tile__header")
 
+    def test_tile_manages_svg_image(self):
+        image_file = "static/artwork/technical-error.svg"
+        image = import_image(image_file, "Sample image")
+
+        body = [
+            (
+                "tile",
+                {
+                    "title": "Sample tile",
+                    "description": RichText('<p data-block-key="test">This is a sample tile.</p>'),
+                    "image": image,
+                },
+            )
+        ]
+
+        self.content_page.body = body
+        self.content_page.save()
+
+        url = self.content_page.url
+
+        response = self.client.get(url)
+
+        self.assertContains(response, "fr-tile__pictogram")
+
 
 class BlogRecentEntriesBlockTestCase(WagtailPageTestCase):
     def setUp(self):

--- a/content_manager/tests/test_views.py
+++ b/content_manager/tests/test_views.py
@@ -159,6 +159,7 @@ class ConfigTestCase(WagtailPageTestCase):
 class MenusTestCase(WagtailPageTestCase):
     @classmethod
     def setUpTestData(cls) -> None:
+        call_command("collectstatic", "--ignore=*.sass", interactive=False)
         call_command("create_starter_pages")
 
     def setUp(self) -> None:

--- a/forms/tests/test_forms.py
+++ b/forms/tests/test_forms.py
@@ -7,6 +7,7 @@ from forms.models import FormPage
 class FormsTestCase(WagtailPageTestCase):
     @classmethod
     def setUpTestData(cls) -> None:
+        call_command("collectstatic", "--ignore=*.sass", interactive=False)
         call_command("create_starter_pages")
 
     def test_form_page_is_renderable(self):


### PR DESCRIPTION
## 🎯 Objectif
Afin de s'assurer que les pictogrammes utilisés dans les modèles de page soient bien présents, il faut les mettre à jour en même temps que le reste.

## 🔍 Implémentation
- [x] Modification des scripts de mise à jour pour inclure la mise à jour des pictogrammes.
- [x] Retrait du collectstatic qui fait double emploi dans le script lui-même
