### PR TITLE
[Semi-rollback] Retrait de la gestion des pictos en mode sombre

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -315,6 +315,7 @@ WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES = (
 )
 
 WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg"]
+SF_SCHEME_DEPENDENT_SVGS = True if os.getenv("SF_SCHEME_DEPENDENT_SVGS", False) == "True" else False
 
 # Allows for complex Streamfields without completely removing checks
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000

--- a/content_manager/templates/content_manager/blocks/image_svg_or_raster.html
+++ b/content_manager/templates/content_manager/blocks/image_svg_or_raster.html
@@ -1,8 +1,9 @@
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags wagtail_dsfr_tags %}
 
 {% image value.image original as artwork %}
+{% settings_value "SF_SCHEME_DEPENDENT_SVGS" as scheme_dependent_svgs %}
 
-{% if artwork.file.name|slice:"-4:" == ".svg" %}
+{% if scheme_dependent_svgs and artwork.file.name|slice:"-4:" == ".svg" %}
   <div class="fr-responsive-img">
     <svg aria-hidden="true" class="fr-artwork" viewBox="0 0 80 80">
       <use class="fr-artwork-decorative" href="{{ artwork.full_url }}#artwork-decorative"></use>

--- a/content_manager/templates/content_manager/blocks/tile.html
+++ b/content_manager/templates/content_manager/blocks/tile.html
@@ -37,8 +37,9 @@
   {% if value.image %}
     <div class="fr-tile__header">
       {% image value.image original as pictogram %}
+      {% settings_value "SF_SCHEME_DEPENDENT_SVGS" as scheme_dependent_svgs %}
 
-      {% if pictogram.file.name|slice:"-4:" == ".svg" %}
+      {% if scheme_dependent_svgs and pictogram.file.name|slice:"-4:" == ".svg" %}
         <div class="fr-tile__pictogram">
           <svg aria-hidden="true"
                class="fr-artwork"

--- a/content_manager/tests/test_blocks.py
+++ b/content_manager/tests/test_blocks.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.test import override_settings
 from wagtail.models import Page
 from wagtail.rich_text import RichText
 from wagtail.test.utils import WagtailPageTestCase
@@ -322,7 +323,8 @@ class TileBlockTestCase(WagtailPageTestCase):
 
         self.assertContains(response, "fr-tile__header")
 
-    def test_tile_manages_svg_image(self):
+    @override_settings(SF_SCHEME_DEPENDENT_SVGS=True)
+    def test_tile_manages_svg_image_if_setting_allows(self):
         image_file = "static/artwork/technical-error.svg"
         image = import_image(image_file, "Sample image")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "content-manager"
-version = "1.10.1"
+version = "1.10.2"
 description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l’État, accessible et responsive"
 authors = [
   "Sébastien Reuiller <sebastien.reuiller@beta.gouv.fr>",


### PR DESCRIPTION
## 🎯 Objectif
Retour en arrière sur #231 : cela empêche les pictogrammes de s'afficher si on utilise un S3 (cause une erreur "Not same-origin" quand l'image est dans une balise `<use>` dans un `<svg>`)

```
Erreur de sécurité : le contenu situé à https://content-manager.osc-fr1.scalingo.io/ ne peut pas charger de données à partir de https://cellar-c2.services.clever-cloud.com/storage-demo/images/Pictogrammes_DSFR__Institutions__Money.original.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ZWM9OJBMLHVWM86C0Y2S%2F20241105%2Feu-west-3%2Fs3%2Faws4_request&X-Amz-Date=20241105T130821Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a6c3e017b2b1f750d5fc26bdefb12756c90a165d76a792d4b2b4e1c5be81104d.
```

## 🔍 Implémentation
- [x] Ajout d'un paramètre `SF_SCHEME_DEPENDENT_SVGS` mis à `False` par défaut pour l'instant
