### PR TITLE
Ajout d'une fonction utilitaire get_default_site()

### DIFF
--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -107,6 +107,4 @@ class BlogTestCase(WagtailPageTestCase):
         self.assertPageIsRenderable(new_blog_post)
 
         response = self.client.get(deep_blog_index_page.url + "rss/")
-        print(deep_blog_index_page.url + "rss/")
-        print(response)
         self.assertEqual(response.status_code, 200)

--- a/content_manager/blocks.py
+++ b/content_manager/blocks.py
@@ -757,8 +757,6 @@ class VerticalContactCardStructValue(blocks.StructValue):
         if len(call_to_action):
             enlarge = False
         elif len(tags):
-            print(tags)
-            print(tags.raw_data)
             tags_list = tags.raw_data
             for tag in tags_list:
                 if (

--- a/content_manager/management/commands/create_demo_pages.py
+++ b/content_manager/management/commands/create_demo_pages.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 from faker import Faker
 from taggit.models import slugify
-from wagtail.models import Site
 from wagtail.rich_text import RichText
 from wagtailmenus.models.menuitems import FlatMenuItem, MainMenuItem
 from wagtailmenus.models.menus import FlatMenu, MainMenu
@@ -9,6 +8,7 @@ from wagtailmenus.models.menus import FlatMenu, MainMenu
 from blog.models import BlogIndexPage
 from content_manager.models import ContentPage, MegaMenu, MegaMenuCategory
 from content_manager.services.accessors import get_or_create_catalog_index_page, get_or_create_content_page
+from content_manager.utils import get_default_site
 from forms.models import FormField, FormPage
 
 ALL_ALLOWED_SLUGS = ["blog_index", "publications", "menu_page", "form"]
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         if not slugs:
             slugs = ALL_ALLOWED_SLUGS
 
-        site = Site.objects.filter(is_default_site=True).first()
+        site = get_default_site()
 
         # First, add the home page to the main menu if not already done
         home_page = site.root_page

--- a/content_manager/management/commands/create_starter_pages.py
+++ b/content_manager/management/commands/create_starter_pages.py
@@ -3,12 +3,13 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.urls import reverse
 from wagtail.images.models import Image
-from wagtail.models import Page, Site
+from wagtail.models import Page
 from wagtail.rich_text import RichText
 from wagtailmenus.models.menuitems import FlatMenuItem, MainMenuItem
 
 from content_manager.models import ContentPage
 from content_manager.services.accessors import get_or_create_footer_menu, get_or_create_main_menu
+from content_manager.utils import get_default_site
 from forms.models import FormField, FormPage
 
 ALL_ALLOWED_SLUGS = ["home", "mentions-legales", "accessibilite", "contact"]
@@ -134,7 +135,7 @@ class Command(BaseCommand):
         home_page = root.add_child(instance=ContentPage(title=title, body=body, show_in_menus=True))
 
         # Define it as default for the default site
-        site = Site.objects.filter(is_default_site=True).first()
+        site = get_default_site()
 
         site.root_page_id = home_page.id
         site.save()
@@ -159,7 +160,7 @@ class Command(BaseCommand):
             self.stdout.write(f"The {slug} page seem to already exist with id {already_exists.id}")
             return
 
-        home_page = Site.objects.filter(is_default_site=True).first().root_page
+        home_page = get_default_site().root_page
         new_page = home_page.add_child(instance=ContentPage(title=title, body=body, slug=slug, show_in_menus=True))
 
         footer_menu = get_or_create_footer_menu()
@@ -199,7 +200,7 @@ class Command(BaseCommand):
 
         thank_you_text = RichText("<p>Merci pour votre message ! Nous reviendrons vers vous rapidement.</p>")
 
-        default_site = Site.objects.filter(is_default_site=True).first()
+        default_site = get_default_site()
         home_page = default_site.root_page
         contact_page = home_page.add_child(
             instance=FormPage(title=title, slug=slug, intro=intro, thank_you_text=thank_you_text, show_in_menus=True)

--- a/content_manager/management/commands/migrate_pages.py
+++ b/content_manager/management/commands/migrate_pages.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
-from wagtail.models import Site
 
 from content_manager.services.import_export import ExportPage, ImportExportImages, ImportPages
+from content_manager.utils import get_default_site
 
 SOURCE_URL = "https://sites-faciles.beta.numerique.gouv.fr/"
 
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
         parent_page_slug = kwargs.get("parent_page_slug")
         if not parent_page_slug:
-            site = Site.objects.filter(is_default_site=True).first()
+            site = get_default_site()
             parent_page_slug = site.root_page.slug
 
         image_folder = Path("/tmp/sf_img")

--- a/content_manager/management/commands/set_config.py
+++ b/content_manager/management/commands/set_config.py
@@ -3,9 +3,10 @@ from os.path import isfile
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from wagtail.models import Group, Site
+from wagtail.models import Group
 
 from content_manager.models import CmsDsfrConfig
+from content_manager.utils import get_default_site
 
 
 class Command(BaseCommand):
@@ -22,7 +23,7 @@ class Command(BaseCommand):
                 without the port or http/https protocol."""
             )
 
-        site = Site.objects.filter(is_default_site=True).first()
+        site = get_default_site()
         site.hostname = settings.HOST_URL
         site.site_name = settings.WAGTAIL_SITE_NAME
         site.save()

--- a/content_manager/tests/test_views.py
+++ b/content_manager/tests/test_views.py
@@ -1,12 +1,13 @@
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from wagtail.models import Page, Site
+from wagtail.models import Page
 from wagtail.rich_text import RichText
 from wagtail.test.utils import WagtailPageTestCase
 from wagtailmenus.models.menuitems import FlatMenuItem, MainMenuItem
 from wagtailmenus.models.menus import FlatMenu, MainMenu
 
 from content_manager.models import CatalogIndexPage, CmsDsfrConfig, ContentPage, MegaMenu, MegaMenuCategory
+from content_manager.utils import get_default_site
 
 
 class ContentPageTestCase(WagtailPageTestCase):
@@ -163,7 +164,7 @@ class MenusTestCase(WagtailPageTestCase):
         call_command("create_starter_pages")
 
     def setUp(self) -> None:
-        self.site = Site.objects.filter(is_default_site=True).first()
+        self.site = get_default_site()
         self.home_page = self.site.root_page
 
         self.main_menu = MainMenu.objects.first()

--- a/content_manager/utils.py
+++ b/content_manager/utils.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from bs4 import BeautifulSoup
 from django.core.files.images import ImageFile
 from wagtail.images.models import Image
+from wagtail.models import Site
 
 
 def import_image(full_path: str, title: str) -> Image:
@@ -18,6 +19,17 @@ def import_image(full_path: str, title: str) -> Image:
         )
         image.save()
         return image
+
+
+def get_default_site() -> Site:
+    """
+    Returns the default site, or the first one if none is set.
+    """
+    site = Site.objects.filter(is_default_site=True).first()
+    if not site:
+        site = Site.objects.filter().first()
+
+    return site
 
 
 def get_streamblock_raw_text(block) -> str:


### PR DESCRIPTION
## 🎯 Objectif
Factorisation : on récupère le site par défaut à de nombreux endroits dans le code. De plus, cela permet de gérer le cas où la case "Site par défaut" a été accidentellement décochée, en prenant dans ce cas le premier site.

## 🔍 Implémentation
- [x] création de la fonction `get_default_site()`

## 🏕 Amélioration continue
- [x] Ajout de message d’erreur explicites dans les accesseurs si le type de la page parente/racine est incorrect
- [x] Retrait de `print()` inutiles

