### PR TITLE
[Bugfix] Résolution du problème d‘import des fichiers sur S3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -134,18 +134,18 @@ webencodings = "*"
 
 [[package]]
 name = "boto3"
-version = "1.34.131"
+version = "1.35.99"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "boto3-1.34.131-py3-none-any.whl", hash = "sha256:05e388cb937e82be70bfd7eb0c84cf8011ff35cf582a593873ac21675268683b"},
-    {file = "boto3-1.34.131.tar.gz", hash = "sha256:dab8f72a6c4e62b4fd70da09e08a6b2a65ea2115b27dd63737142005776ef216"},
+    {file = "boto3-1.35.99-py3-none-any.whl", hash = "sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71"},
+    {file = "boto3-1.35.99.tar.gz", hash = "sha256:e0abd794a7a591d90558e92e29a9f8837d25ece8e3c120e530526fe27eba5fca"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.131,<1.35.0"
+botocore = ">=1.35.99,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -154,14 +154,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.162"
+version = "1.35.99"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "botocore-1.34.162-py3-none-any.whl", hash = "sha256:2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be"},
-    {file = "botocore-1.34.162.tar.gz", hash = "sha256:adc23be4fb99ad31961236342b7cbf3c0bfc62532cd02852196032e8c0d682f3"},
+    {file = "botocore-1.35.99-py3-none-any.whl", hash = "sha256:b22d27b6b617fc2d7342090d6129000af2efd20174215948c0d7ae2da0fab445"},
+    {file = "botocore-1.35.99.tar.gz", hash = "sha256:1eab44e969c39c5f3d9a3104a0836c24715579a455f12b3979a31d7cde51b3c3"},
 ]
 
 [package.dependencies]
@@ -170,7 +170,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
-crt = ["awscrt (==0.21.2)"]
+crt = ["awscrt (==0.22.0)"]
 
 [[package]]
 name = "certifi"
@@ -2412,4 +2412,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<4.0,>=3.10"
-content-hash = "9a4f06c8812d23d8cd24210ead8cc9c1e8986802d56dde542ee05df1bf25fb88"
+content-hash = "ffb1511217e34dec7a7e2405887af214f25f9afa79982dd51f8473b906ffd3f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "wagtail-markdown<1.0.0,>=0.11.1",
     "unidecode<2.0.0,>=1.3.8",
     "django-storages[s3]<2.0.0,>=1.14.2",
-    "boto3==1.34.131",
+    "boto3==1.35.99",
     "beautifulsoup4<5.0.0,>=4.12.3",
     "django-taggit<6.0.0,>=5.0.1",
     "wagtail-localize<2.0,>=1.9",


### PR DESCRIPTION
## 🎯 Objectif
Les imports d‘image ne fonctionnent plus sur S3 suite à une mise à jour de `boto3`, cf. #255 

Le problème semble être lié à la version 1.36.1

## 🔍 Implémentation
- [x] Verrouillage de la version de `boto3` en 1.35.99

