### PR TITLE
Improvements to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,8 @@ fix:
 index:
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py update_index
 
-.PHONY: init
-init:
-	$(EXEC_CMD) poetry install --no-root --without dev
+.PHONY: first-deploy
+first-deploy:
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py migrate
 	make collectstatic
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py set_config
@@ -58,21 +57,29 @@ init:
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py import_page_templates
 	make index
 
+.PHONY: init
+init:
+	$(EXEC_CMD) poetry install --no-root --without dev
+	make first-deploy
+
 .PHONY: init-dev
 init-dev:
-	make init
 	$(EXEC_CMD) poetry install --no-root
+	make first-deploy
 	$(EXEC_CMD) $(POETRY_CMD) pre-commit install
 
-
-.PHONY: update
-update:
-	$(EXEC_CMD) poetry install --no-root --without dev
+.PHONY: deploy
+deploy:
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py migrate
 	make collectstatic
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py import_dsfr_pictograms
 	$(EXEC_CMD) $(POETRY_CMD) python manage.py import_page_templates
 	make index
+
+.PHONY: update
+update:
+	$(EXEC_CMD) poetry install --no-root --without dev
+	make deploy
 
 .PHONY: demo
 demo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sites-faciles"
 requires-python = "<4.0,>=3.10"
-version = "1.11.4"
+version = "1.11.5"
 description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l’État, accessible et responsive"
 authors = [
     {name = "Sébastien Reuiller", email = "sebastien.reuiller@beta.gouv.fr"},


### PR DESCRIPTION
## 🎯 Objectif
Même avec la nouvelle variable `USE_POETRY`, certaines commandes dépendent de poetry et il faut donc les séparer pour pouvoir les utiliser sur Scalingo

## 🔍 Implémentation
- [x] Création de deux nouvelles commandes `make first-deploy` et `make-deploy` pour remplacer `make init` et make `update` sur scalingo

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
