### PR TITLE
Mise à jour de Wagtail en version 6.4

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,17 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DJANGO_SETTINGS_MODULE: config.settings_test
-      PYTHONPATH: .
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        # Only include the first and last supported pgsql versions to limit
+        # the number of jobs
+        postgresql-version: [13, 17]
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:${{ matrix.postgresql-version }}-alpine
         env:
           POSTGRES_USER: dju
           POSTGRES_PASSWORD: djpwd
           POSTGRES_DB: djdb
+          POSTGRESQL_VERSION: ${{ matrix.postgresql-version }}
         ports:
           - 5432:5432
     steps:

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,7 +35,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True if os.getenv("DEBUG") == "True" else False
 
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "127.0.0.1, localhost").replace(" ", "").split(",")
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "127.0.0.1,.localhost").replace(" ", "").split(",")
 
 HOST_URL = os.getenv("HOST_URL", "localhost")
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.urls import include, path
+from django.views.generic.base import RedirectView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
@@ -11,6 +12,7 @@ urlpatterns = [
     path(settings.WAGTAILADMIN_PATH, include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("api/v2/", api_router.urls),
+    path("favicon.ico", RedirectView.as_view(url="/static/dsfr/dist/favicon/favicon.ico", permanent=True)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns += i18n_patterns(

--- a/dashboard/wagtail_hooks.py
+++ b/dashboard/wagtail_hooks.py
@@ -43,5 +43,5 @@ class UserbarPageAPILinkItem:
 
 
 @hooks.register("construct_wagtail_userbar")
-def add_page_api_link_item(request, items):
+def add_page_api_link_item(request, items, page):
     return items.append(UserbarPageAPILinkItem())

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+set dotenv-load
+set shell := ["bash", "-uc"]
+
+poetry_run := if env("USE_POETRY", "0") == "1" { "poetry run" } else { "" }
+
+default:
+    just -l
+
+alias mm:= makemigrations
+makemigrations app="":
+    {{poetry_run}} python manage.py makemigrations {{app}}
+
+alias mi := migrate
+migrate app="" version="":
+    {{poetry_run}} python manage.py migrate {{app}} {{version}}
+
+mmi:
+    just makemigrations
+    just migrate
+
+test app="":
+    {{poetry_run}} python manage.py test {{app}} --buffer --parallel
+
+unittest app="":
+    {{poetry_run}} python manage.py test {{app}} --settings config.settings_test

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,14 +174,14 @@ crt = ["awscrt (==0.22.0)"]
 
 [[package]]
 name = "certifi"
-version = "2024.12.14"
+version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
-    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
+    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
+    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
 
 [[package]]
@@ -327,13 +327,14 @@ files = [
 
 [[package]]
 name = "cssbeautifier"
-version = "1.15.1"
+version = "1.15.3"
 description = "CSS unobfuscator and beautifier."
 optional = false
 python-versions = "*"
 groups = ["dev"]
 files = [
-    {file = "cssbeautifier-1.15.1.tar.gz", hash = "sha256:9f7064362aedd559c55eeecf6b6bed65e05f33488dcbe39044f0403c26e1c006"},
+    {file = "cssbeautifier-1.15.3-py3-none-any.whl", hash = "sha256:0dcaf5ce197743a79b3a160b84ea58fcbd9e3e767c96df1171e428125b16d410"},
+    {file = "cssbeautifier-1.15.3.tar.gz", hash = "sha256:406b04d09e7d62c0be084fbfa2cba5126fe37359ea0d8d9f7b963a6354fc8303"},
 ]
 
 [package.dependencies]
@@ -409,14 +410,14 @@ static3 = "*"
 
 [[package]]
 name = "django"
-version = "5.1.5"
+version = "5.1.6"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "Django-5.1.5-py3-none-any.whl", hash = "sha256:c46eb936111fffe6ec4bc9930035524a8be98ec2f74d8a0ff351226a3e52f459"},
-    {file = "Django-5.1.5.tar.gz", hash = "sha256:19bbca786df50b9eca23cee79d495facf55c8f5c54c529d9bf1fe7b5ea086af3"},
+    {file = "Django-5.1.6-py3-none-any.whl", hash = "sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5"},
+    {file = "Django-5.1.6.tar.gz", hash = "sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690"},
 ]
 
 [package.dependencies]
@@ -430,14 +431,14 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-appconf"
-version = "1.0.6"
+version = "1.1.0"
 description = "A helper class for handling configuration defaults of packaged apps gracefully."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "django-appconf-1.0.6.tar.gz", hash = "sha256:cfe87ea827c4ee04b9a70fab90b86d704cb02f2981f89da8423cb0fabf88efbf"},
-    {file = "django_appconf-1.0.6-py3-none-any.whl", hash = "sha256:c3ae442fba1ff7ec830412c5184b17169a7a1e71cf0864a4c3f93cf4c98a1993"},
+    {file = "django-appconf-1.1.0.tar.gz", hash = "sha256:9fcead372f82a0f21ee189434e7ae9c007cbb29af1118c18251720f3d06243e4"},
+    {file = "django_appconf-1.1.0-py3-none-any.whl", hash = "sha256:7abd5a163ff57557f216e84d3ce9dac36c37ffce1ab9a044d3d53b7c943dd10f"},
 ]
 
 [package.dependencies]
@@ -610,14 +611,14 @@ management-command = ["django-compressor (>=2.4)"]
 
 [[package]]
 name = "django-storages"
-version = "1.14.4"
+version = "1.14.5"
 description = "Support for many storage backends in Django"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "django-storages-1.14.4.tar.gz", hash = "sha256:69aca94d26e6714d14ad63f33d13619e697508ee33ede184e462ed766dc2a73f"},
-    {file = "django_storages-1.14.4-py3-none-any.whl", hash = "sha256:d61930acb4a25e3aebebc6addaf946a3b1df31c803a6bf1af2f31c9047febaa3"},
+    {file = "django_storages-1.14.5-py3-none-any.whl", hash = "sha256:5ce9c69426f24f379821fd688442314e4aa03de87ae43183c4e16915f4c165d4"},
+    {file = "django_storages-1.14.5.tar.gz", hash = "sha256:ace80dbee311258453e30cd5cfd91096b834180ccf09bc1f4d2cb6d38d68571a"},
 ]
 
 [package.dependencies]
@@ -628,10 +629,26 @@ Django = ">=3.2"
 azure = ["azure-core (>=1.13)", "azure-storage-blob (>=12)"]
 boto3 = ["boto3 (>=1.4.4)"]
 dropbox = ["dropbox (>=7.2.1)"]
-google = ["google-cloud-storage (>=1.27)"]
+google = ["google-cloud-storage (>=1.32)"]
 libcloud = ["apache-libcloud"]
 s3 = ["boto3 (>=1.4.4)"]
 sftp = ["paramiko (>=1.15)"]
+
+[[package]]
+name = "django-stubs-ext"
+version = "5.1.3"
+description = "Monkey-patching and extensions for django-stubs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "django_stubs_ext-5.1.3-py3-none-any.whl", hash = "sha256:64561fbc53e963cc1eed2c8eb27e18b8e48dcb90771205180fe29fc8a59e55fd"},
+    {file = "django_stubs_ext-5.1.3.tar.gz", hash = "sha256:3e60f82337f0d40a362f349bf15539144b96e4ceb4dbd0239be1cd71f6a74ad0"},
+]
+
+[package.dependencies]
+django = "*"
+typing-extensions = "*"
 
 [[package]]
 name = "django-taggit"
@@ -647,6 +664,28 @@ files = [
 
 [package.dependencies]
 Django = ">=4.1"
+
+[[package]]
+name = "django-tasks"
+version = "0.6.1"
+description = "An implementation and backport of background workers and tasks in Django"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "django_tasks-0.6.1-py3-none-any.whl", hash = "sha256:b3648e28bdcda809cb7831f3aff98aa46c327025447c462b8943cce9dfbb0281"},
+    {file = "django_tasks-0.6.1.tar.gz", hash = "sha256:4086e7eb9e965f79c4ac76f5c3690ec3bf41c461585237b71b4bde729ced9826"},
+]
+
+[package.dependencies]
+Django = ">=4.2"
+django-stubs-ext = "*"
+typing_extensions = "*"
+
+[package.extras]
+dev = ["coverage", "dj-database-url", "django-stubs[compatible-mypy]", "ruff"]
+mysql = ["mysqlclient"]
+postgres = ["psycopg[binary]"]
 
 [[package]]
 name = "django-treebeard"
@@ -907,14 +946,14 @@ pytz = "*"
 
 [[package]]
 name = "identify"
-version = "2.6.6"
+version = "2.6.7"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881"},
-    {file = "identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251"},
+    {file = "identify-2.6.7-py2.py3-none-any.whl", hash = "sha256:155931cb617a401807b09ecec6635d6c692d180090a1cedca8ef7d58ba5b6aa0"},
+    {file = "identify-2.6.7.tar.gz", hash = "sha256:3fa266b42eba321ee0b2bb0936a6a6b9e36a1351cbb69055b3082f4193035684"},
 ]
 
 [package.extras]
@@ -937,14 +976,14 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "ipython"
-version = "8.31.0"
+version = "8.32.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "ipython-8.31.0-py3-none-any.whl", hash = "sha256:46ec58f8d3d076a61d128fe517a51eb730e3aaf0c184ea8c17d16e366660c6a6"},
-    {file = "ipython-8.31.0.tar.gz", hash = "sha256:b6a2274606bec6166405ff05e54932ed6e5cfecaca1fc05f2cacde7bb074d70b"},
+    {file = "ipython-8.32.0-py3-none-any.whl", hash = "sha256:cae85b0c61eff1fc48b0a8002de5958b6528fa9c8defb1894da63f42613708aa"},
+    {file = "ipython-8.32.0.tar.gz", hash = "sha256:be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251"},
 ]
 
 [package.dependencies]
@@ -1023,13 +1062,14 @@ files = [
 
 [[package]]
 name = "jsbeautifier"
-version = "1.15.1"
+version = "1.15.3"
 description = "JavaScript unobfuscator and beautifier."
 optional = false
 python-versions = "*"
 groups = ["dev"]
 files = [
-    {file = "jsbeautifier-1.15.1.tar.gz", hash = "sha256:ebd733b560704c602d744eafc839db60a1ee9326e30a2a80c4adb8718adc1b24"},
+    {file = "jsbeautifier-1.15.3-py3-none-any.whl", hash = "sha256:b207a15ab7529eee4a35ae7790e9ec4e32a2b5026d51e2d0386c3a65e6ecfc91"},
+    {file = "jsbeautifier-1.15.3.tar.gz", hash = "sha256:5f1baf3d4ca6a615bb5417ee861b34b77609eeb12875555f8bbfabd9bf2f3457"},
 ]
 
 [package.dependencies]
@@ -1050,22 +1090,6 @@ files = [
 
 [package.extras]
 dev = ["build (==1.2.2.post1)", "coverage (==7.5.3)", "mypy (==1.13.0)", "pip (==24.3.1)", "pylint (==3.2.3)", "ruff (==0.7.3)", "twine (==5.1.1)", "uv (==0.5.1)"]
-
-[[package]]
-name = "l18n"
-version = "2021.3"
-description = "Internationalization for pytz timezones and territories"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "l18n-2021.3-py3-none-any.whl", hash = "sha256:78495d1df95b6f7dcc694d1ba8994df709c463a1cbac1bf016e1b9a5ce7280b9"},
-    {file = "l18n-2021.3.tar.gz", hash = "sha256:1956e890d673d17135cc20913253c154f6bc1c00266c22b7d503cc1a5a42d848"},
-]
-
-[package.dependencies]
-pytz = ">=2020.1"
-six = "*"
 
 [[package]]
 name = "laces"
@@ -1633,14 +1657,14 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
-version = "2024.2"
+version = "2025.1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
-    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
+    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
 ]
 
 [[package]]
@@ -1974,6 +1998,31 @@ files = [
 ]
 
 [[package]]
+name = "rust-just"
+version = "1.39.0"
+description = "🤖 Just a command runner"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "rust_just-1.39.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3845ab10254c994ddebcf489b30c53a24c1d11585c9e0eeaf1cb0da422bee87f"},
+    {file = "rust_just-1.39.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fd5c12118a8d65266ccdacfbc24bab26f77d509caaf263095cb96611ea6ce7e8"},
+    {file = "rust_just-1.39.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:428d07b1e798777c4e9a8c245539d72743be095558010f0a86823e1c442930f9"},
+    {file = "rust_just-1.39.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:135a7a65a8641b00a2fe7f3156a97ab7052e4830a922a71e67ca4e38ccd54cd2"},
+    {file = "rust_just-1.39.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94eb45e585fda019f7f9cbac198e10e31f81c704371887cbdec9b7a1ae2e0d29"},
+    {file = "rust_just-1.39.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de4a8566ca1eb87b5ff2669a6dd9474b16977c5d712534a5a9c7a950271da2d0"},
+    {file = "rust_just-1.39.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7ecd8fd862729c243498951caa54d778ff480c2524039280ff3ebb9a64299f"},
+    {file = "rust_just-1.39.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:576229024d2ef8fc696d5a049ecd0d8f3d9b920a32e76f65e95840d24d804101"},
+    {file = "rust_just-1.39.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c1cd9240e2c1b352d7ccc6b89ce84fcc0352f15bb9660cdc6bc34802b36251b6"},
+    {file = "rust_just-1.39.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d6eff0461df7e36eba6e7f0addf16ef98563cf8cb483e4c8393be5456d6af5c6"},
+    {file = "rust_just-1.39.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0dfcc49a5fa126ba923b58e48921fd117e429660495577a854494c6ced3134c9"},
+    {file = "rust_just-1.39.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:826203ad02c869ad8621993a608adb01394ef9c9c9ca6aa7dd7875b1f272aa46"},
+    {file = "rust_just-1.39.0-py3-none-win32.whl", hash = "sha256:dcef0926b287449e853b878f6f34759a797d017cefb83afbcd74820d37259b78"},
+    {file = "rust_just-1.39.0-py3-none-win_amd64.whl", hash = "sha256:3139f3f76434a8ebbf35b213d149e647c4d9546312b438e262df7ec41e7ef7bc"},
+    {file = "rust_just-1.39.0.tar.gz", hash = "sha256:247d0b293924cc8089a73428c9c03a3c2c0627bb8f205addb976ded0681f0dac"},
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.10.4"
 description = "An Amazon S3 Transfer Manager"
@@ -2220,14 +2269,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.29.1"
+version = "20.29.2"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779"},
-    {file = "virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35"},
+    {file = "virtualenv-20.29.2-py3-none-any.whl", hash = "sha256:febddfc3d1ea571bdb1dc0f98d7b45d24def7428214d4fb73cc486c9568cce6a"},
+    {file = "virtualenv-20.29.2.tar.gz", hash = "sha256:fdaabebf6d03b5ba83ae0a02cfe96f48a716f4fae556461d180825866f75b728"},
 ]
 
 [package.dependencies]
@@ -2241,14 +2290,14 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "wagtail"
-version = "6.3.2"
+version = "6.4"
 description = "A Django content management system."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "wagtail-6.3.2-py3-none-any.whl", hash = "sha256:ac72f7138281ef47360057ebfb835a8eae34048efeed10ca9f4aabbc8f4e4ea5"},
-    {file = "wagtail-6.3.2.tar.gz", hash = "sha256:e4271222bd2498040a60dd5e27228dcd481cc2310aa8fc951f0f4e23d20fbc50"},
+    {file = "wagtail-6.4-py3-none-any.whl", hash = "sha256:3d89b93079711fd1703be057a06cf5d34303a20ee31b2f51384954e21fff38ce"},
+    {file = "wagtail-6.4.tar.gz", hash = "sha256:3e311f367867741a2a025ae1c6d498c177ae1936a4b92444177804fa713edff0"},
 ]
 
 [package.dependencies]
@@ -2259,10 +2308,10 @@ django-filter = ">=23.3,<25"
 django-modelcluster = ">=6.2.1,<7.0"
 django-permissionedforms = ">=0.1,<1.0"
 django-taggit = ">=5.0,<6.2"
+django-tasks = ">=0.6.1,<0.7"
 django-treebeard = ">=4.5.1,<5.0"
 djangorestframework = ">=3.15.1,<4.0"
 draftjs-exporter = ">=2.1.5,<6.0"
-l18n = ">=2018.5"
 laces = ">=0.1,<0.2"
 openpyxl = ">=3.0.10,<4.0"
 Pillow = ">=9.1.0,<12.0.0"
@@ -2276,14 +2325,14 @@ testing = ["Jinja2 (>=3.0,<3.2)", "azure-mgmt-cdn (>=12.0,<13.0)", "azure-mgmt-f
 
 [[package]]
 name = "wagtail-localize"
-version = "1.11.1"
+version = "1.11.3"
 description = "Translation plugin for Wagtail CMS"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "wagtail_localize-1.11.1-py3-none-any.whl", hash = "sha256:e5c41bb0417a864f7612fe7ce9070fafc0c0e7f017c29d3bb19b0b5d0d24f9bd"},
-    {file = "wagtail_localize-1.11.1.tar.gz", hash = "sha256:10502d0a8a69bdd1fb72cfb3fb9eeaafe8329b84779b71f6bd651c096eb5abd4"},
+    {file = "wagtail_localize-1.11.3-py3-none-any.whl", hash = "sha256:60f17c110bf368489ef40e39ed1d65b82d2768052b69462c6cb2fac44c77f331"},
+    {file = "wagtail_localize-1.11.3.tar.gz", hash = "sha256:bd2e57b0afbeaff741d49e7de14bab9de96767273f8f3978076a0413dbe630f6"},
 ]
 
 [package.dependencies]
@@ -2412,4 +2461,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<4.0,>=3.10"
-content-hash = "c9ea1630fbb9c358c5c246ddf680db4fcd9a50a068f77650a0987c1806f8a7ed"
+content-hash = "28c1df4e0902b1948cee87987da7e88c8603b9cc848236d999dabe2794f7c303"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sites-faciles"
 requires-python = "<4.0,>=3.10"
-version = "1.12.0"
+version = "1.13.0"
 description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l’État, accessible et responsive"
 authors = [
     {name = "Sébastien Reuiller", email = "sebastien.reuiller@beta.gouv.fr"},
@@ -33,6 +33,7 @@ dependencies = [
     "wagtail-localize<2.0,>=1.9",
     "icalendar<6.0.0,>=5.0.13",
     "faker<25.0.0,>=24.3.0",
+    "rust-just (>=1.39.0,<2.0.0)",
 ]
 
 [tool.poetry]

--- a/templates/menus/custom_flat_menu.html
+++ b/templates/menus/custom_flat_menu.html
@@ -1,9 +1,9 @@
 {% load menu_tags %}
 {% for item in menu_items %}
-    <li>
-        <a href="{{ item.href }}"
-            class="fr-btn"
-            {% if item.active_class %} aria-current="page"{% endif %}
-            target="_self">{{ item.text }}</a>
-    </li>
+  <li>
+    <a href="{{ item.href }}"
+       class="fr-btn"
+       {% if item.active_class %}aria-current="page"{% endif %}
+       target="_self">{{ item.text }}</a>
+  </li>
 {% endfor %}

--- a/templates/menus/custom_flat_menu_footer.html
+++ b/templates/menus/custom_flat_menu_footer.html
@@ -1,8 +1,8 @@
 {% for item in menu_items %}
-    <li class="fr-footer__bottom-item">
-        <a href="{{ item.href }}"
-            class="fr-footer__bottom-link"
-            {% if item.active_class %} aria-current="page"{% endif %}
-            target="_self">{{ item.text }}</a>
-    </li>
+  <li class="fr-footer__bottom-item">
+    <a href="{{ item.href }}"
+       class="fr-footer__bottom-link"
+       {% if item.active_class %}aria-current="page"{% endif %}
+       target="_self">{{ item.text }}</a>
+  </li>
 {% endfor %}

--- a/templates/menus/custom_main_menu.html
+++ b/templates/menus/custom_main_menu.html
@@ -1,25 +1,25 @@
 {% load menu_tags wagtail_dsfr_tags %}
 <ul class="fr-nav__list">
-    {% for item in menu_items %}
-        <li class="fr-nav__item">
-            {% if item.id in mega_menus %}
-                <button class="fr-nav__btn"
-                        aria-expanded="false"
-                        {% if item.active_class %}aria-current="true"{% endif %}
-                        aria-controls="mega-menu-{{ item.id }}">{{ item.text }}</button>
-                {% mega_menu item.id %}
-            {% elif item.has_children_in_menu %}
-                <button class="fr-nav__btn"
-                        aria-expanded="false"
-                        {% if item.active_class %}aria-current="true"{% endif %}
-                        aria-controls="menu-{{ item.link_page.pk }}">{{ item.text }}</button>
-                {% sub_menu item template="menus/custom_sub_menu.html" %}
-            {% else %}
-                <a href="{{ item.href }}"
-                   class="fr-nav__link"
-                   {% if item.active_class %}aria-current="page"{% endif %}
-                   target="_self">{{ item.text }}</a>
-            {% endif %}
-        </li>
-    {% endfor %}
+  {% for item in menu_items %}
+    <li class="fr-nav__item">
+      {% if item.id in mega_menus %}
+        <button class="fr-nav__btn"
+                aria-expanded="false"
+                {% if item.active_class %}aria-current="true"{% endif %}
+                aria-controls="mega-menu-{{ item.id }}">{{ item.text }}</button>
+        {% mega_menu item.id %}
+      {% elif item.has_children_in_menu %}
+        <button class="fr-nav__btn"
+                aria-expanded="false"
+                {% if item.active_class %}aria-current="true"{% endif %}
+                aria-controls="menu-{{ item.link_page.pk }}">{{ item.text }}</button>
+        {% sub_menu item template="menus/custom_sub_menu.html" %}
+      {% else %}
+        <a href="{{ item.href }}"
+           class="fr-nav__link"
+           {% if item.active_class %}aria-current="page"{% endif %}
+           target="_self">{{ item.text }}</a>
+      {% endif %}
+    </li>
+  {% endfor %}
 </ul>

--- a/templates/menus/custom_sub_menu.html
+++ b/templates/menus/custom_sub_menu.html
@@ -1,15 +1,15 @@
 {% load menu_tags %}
 {% if menu_items %}
-    <div class="fr-collapse fr-menu" id="menu-{{ parent_page.pk }}">
-        <ul class="fr-menu__list">
-            {% for item in menu_items %}
-                <li>
-                    <a class="fr-nav__link"
-                       href="{{ item.href }}"
-                       {% if item.active_class %}aria-current="page"{% endif %}
-                       target="_self">{{ item.text }}</a>
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
+  <div class="fr-collapse fr-menu" id="menu-{{ parent_page.pk }}">
+    <ul class="fr-menu__list">
+      {% for item in menu_items %}
+        <li>
+          <a class="fr-nav__link"
+             href="{{ item.href }}"
+             {% if item.active_class %}aria-current="page"{% endif %}
+             target="_self">{{ item.text }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
 {% endif %}


### PR DESCRIPTION
## 🎯 Objectif
Mettre à jour Wagtail en version 6.4

## 🔍 Implémentation
- [x] Mise à jour des dépendances Python :

```
  - Removing l18n (2021.3)
  - Updating django (5.1.5 -> 5.1.6)
  - Updating certifi (2024.12.14 -> 2025.1.31)
  - Updating django-stubs-ext (5.1.2 -> 5.1.3)
  - Updating jsbeautifier (1.15.1 -> 1.15.3)
  - Updating cssbeautifier (1.15.1 -> 1.15.3): Installing...
  - Updating django-appconf (1.0.6 -> 1.1.0)
  - Updating identify (2.6.6 -> 2.6.7)
  - Updating pytz (2024.2 -> 2025.1): Installing...
  - Updating virtualenv (20.29.1 -> 20.29.2): Installing...
  - Updating wagtail (6.3.2 -> 6.4): Installing...
```

## 🏕 Amélioration continue
- [x] Début de transfert des recettes de `make` vers `just` (ajout de la dépendance `rust-just`)
- [x] Gestion de multiples versions de PostgreSQL dans la CI
- [x] Ajout d’une redirection de `/favicon.ico` vers le bon chemin (supprime une alerte dans les logs)
- [x] Dans ` dashboard/wagtail_hooks.py`, ajout du paramètre `page` à la fonction `add_page_api_link_item` (supprime une alerte dans les logs
- [x] Correction d’indentation sur certains templates

## 🖼️ Images
