### PR TITLE
Génération automatique d'un sitemap.xml

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sitemaps",
     "django.contrib.staticfiles",
     "widget_tweaks",
     "dsfr",

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
+from wagtail.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -8,6 +9,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 from config.api import api_router
 
 urlpatterns = [
+    path("sitemap.xml", sitemap,),
     path(settings.WAGTAILADMIN_PATH, include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("api/v2/", api_router.urls),


### PR DESCRIPTION
## 🎯 Objectif

Produire automatiquement un fichier sitemap.xml dans le but d'améliorer l'indexation des pages par les moteurs de recherche.
Le sitemap est à la racine du site pour prendre en compte l'ensemble des pages publiées.

## 🔍 Implémentation

La génération utilise le système de sitemap fourni par Wagtail:
https://docs.wagtail.org/en/stable/reference/contrib/sitemaps.html
