### PR TITLE
Corrige l'accessibilité du champs recherche

### DIFF
--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -64,7 +64,7 @@
             <input class="fr-input"
                    placeholder="{{ search_label }}"
                    type="search"
-                   id="query"
+                   id="search-bar-input"
                    name="q">
             <button class="fr-btn" title="{{ search_label }}">{{ search_label }}</button>
           </div>


### PR DESCRIPTION
## 🎯 Objectif

Le champs de recherche a un label avec un attribut "for" qui n'est pas le même que l'id de l'input
closes #273 

## 🔍 Implémentation

- Changer l'id de l'input pour qu'il corresponde au label

