### PR TITLE
Accessibilité des liens externes

### DIFF
--- a/content_manager/templates/content_manager/blocks/button.html
+++ b/content_manager/templates/content_manager/blocks/button.html
@@ -3,7 +3,7 @@
   <a class="{{ button.button_type }}{% if button.icon_side %} {{ button.icon_side }} {{ button.icon_class }}{% endif %}"
      href="{{ button.url }}"
      target="_blank"
-     rel="noopener external">{{ button.text }}<span class="fr-sr-only">{% translate "Opens a new window" %}</span></a>
+     rel="noopener external">{{ button.text }} <span class="fr-sr-only">{% translate "Opens a new window" %}</span></a>
 {% else %}
   <a class="{{ button.button_type }}{% if button.icon_side %} {{ button.icon_side }} {{ button.icon_class }}{% endif %}"
      href="{{ button.url }}">{{ button.text }}</a>

--- a/content_manager/templates/content_manager/blocks/button.html
+++ b/content_manager/templates/content_manager/blocks/button.html
@@ -2,7 +2,7 @@
   <a class="{{ button.button_type }}{% if button.icon_side %} {{ button.icon_side }} {{ button.icon_class }}{% endif %}"
      href="{{ button.url }}"
      target="_blank"
-     rel="noopener external">{{ button.text }}</a>
+     rel="noopener external">{{ button.text }}<span class="fr-sr-only"> Ouvre dans une nouvelle fenêtre</span></a>
 {% else %}
   <a class="{{ button.button_type }}{% if button.icon_side %} {{ button.icon_side }} {{ button.icon_class }}{% endif %}"
      href="{{ button.url }}">{{ button.text }}</a>

--- a/content_manager/templates/content_manager/blocks/button.html
+++ b/content_manager/templates/content_manager/blocks/button.html
@@ -1,8 +1,9 @@
+{% load i18n %}
 {% if button.external_url %}
   <a class="{{ button.button_type }}{% if button.icon_side %} {{ button.icon_side }} {{ button.icon_class }}{% endif %}"
      href="{{ button.url }}"
      target="_blank"
-     rel="noopener external">{{ button.text }}<span class="fr-sr-only"> Ouvre dans une nouvelle fenêtre</span></a>
+     rel="noopener external">{{ button.text }}<span class="fr-sr-only">{% translate "Opens a new window" %}</span></a>
 {% else %}
   <a class="{{ button.button_type }}{% if button.icon_side %} {{ button.icon_side }} {{ button.icon_class }}{% endif %}"
      href="{{ button.url }}">{{ button.text }}</a>


### PR DESCRIPTION
## 🎯 Objectif

Quand un lien redirige vers une url externe il n'y a qu'une information présente dans un ::after qui n'est donc pas visible quand il n'y a pas de feuille de style d'activé.

Critère 10.2  Dans chaque page web, le [contenu visible (ouvre dans une nouvelle fenêtre)](https://accessibilite.numerique.gouv.fr/methode/glossaire/#contenu-visible)porteur d’information reste-t-il présent lorsque les [feuilles de styles (ouvre dans une nouvelle fenêtre)](https://accessibilite.numerique.gouv.fr/methode/glossaire/#feuille-de-style)sont désactivées ?

## 🔍 Implémentation

- ajouter une information "Ouvre dans une nouvelle fenêtre" avec une class "sr-only"

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images
![Capture d’écran 2025-02-28 à 15 16 55](https://github.com/user-attachments/assets/a62ad8b0-bdf6-4cf2-8d1c-00f13a870882)
Avant :
![Capture d’écran 2025-02-28 à 15 16 49](https://github.com/user-attachments/assets/40e224e1-04ea-4a1c-b2ae-8ed65aaf92c8)
Après :
![Capture d’écran 2025-02-28 à 15 18 28](https://github.com/user-attachments/assets/bc8b92ad-a9e7-46f5-8bce-17834f12f816)


