### PR TITLE
facilitation d'une première mise en place en corrigeant le fichier d'exemple

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,9 @@ DEBUG=False
 HOST_PROTO=http
 # HOST_URL and ALLOWED_HOSTS: use 0.0.0.0 for Docker
 HOST_URL=localhost
-ALLOWED_HOSTS=localhost, 127.0.0.1
+ALLOWED_HOSTS=localhost,127.0.0.1
 HOST_PORT=8000
-SITE_NAME=Sites faciles
+SITE_NAME="Sites faciles"
 MEDIA_ROOT=medias
 
 # USE_DOCKER: Set 1 to use Docker


### PR DESCRIPTION
Suppression d'erreurs lors du chargement d'un fichier `.env` issu d'un copié-collé de `.env.example` si les variables d'environnement sont chargées par `direnv`. Les erreurs viennent des espaces contenus dans les valeurs à charger.

Dans le cas contraire, des erreurs de ce type seront affichées :

```
direnv: error invalid line: ALLOWED_HOSTS=localhost, 127.0.0.1
```

`direnv` est un outil libre, largement disponible dans les distributions.

http://direnv.net/