### PR TITLE
ajout d'une URL canonique pour avoir moins d'URL dupliquées

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
       <meta charset="utf-8" />
       <meta name="viewport"
             content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      <link rel="canonical" href="{{ request.scheme }}{{ request.get_host }}{{ request.path }}">
       {% block title %}
         <title>
           {% if title %}{{ title }} —{% endif %}


### PR DESCRIPTION
Dans le but d'améliorer le référencement, il est nécessaire d'éliminer les URL dupliquées détectées par Google Search Console. En particulier les URL suivis de paramètres sont considérées comme les pages dupliquées alors que ces paramètres n'ont pas d'effet de différenciation (par exemple les paramètres pour Matomo).

La définition d'une URL canonique, sans ces paramètres, permet de corriger cela.

Il n'est pas possible d'utiliser simplement `request.get_full_path` dans le template car, dans ce cas, les paramètres `GET` sont aussi affichés dans l'URL canonique. Le but de la définition de l'URL canonique est les supprimer pour que les différentes URL ne soient plus considérées comme unique mais bien comme la même page.

L'implémentation utilisée suppose qu'il n'existe qu'un seul domaine qui fournit les pages. S'il y a plusieurs domaines (ou http et https), ils doivent tous rediriger vers le domaine de référence.

Étant donné que l'hypothèse n'est pas forcément vraie, je comprendrai que ce ne soit pas acceptable (ou qu'il faudrait la rendre facultative par exemple).