### PR TITLE
Mettre le bloc « Lettre d’information et réseaux sociaux » dans un aside

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -66,7 +66,7 @@
 
       {% block follow_newsletter_social_media %}
         {% if SiteConfig.show_newsletter_and_social_block %}
-          <aside role="complementary" id="cmsfr-follow">
+          <aside role="complementary" id="cmsfr-block-follow">
             {% include "blocks/follow.html" %}
           </aside>
         {% endif %}


### PR DESCRIPTION
## 🎯 Objectif

Cf. https://github.com/numerique-gouv/django-dsfr/pull/210 :

Suite à un audit de numerique.gouv un problème a été remonté, le block newsletter de Sites-Faciles n'est ni dans la balise <main> ni dans la balise <footer>. Une suggestion a été de le mettre dans un `<aside>` : 

> ÀMHA ce bloc répété, complémentaire du contenu principal, est à identifier en tant que tel -> aside (role="complementary")
sinon dans un élément navigation.
le footer (role="contentinfo") est normalement réservé à des métadonnées : de l’information à propos du contenu.
La newsletter n’est pas de l’information à propos du contenu (comme les mentions légales ou la déclaration d’accessibilité), c’est un contenu en soi du site.


## 🔍 Implémentation
- [x] Ajout de la balise

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
