### PR TITLE
Grille d’éléments : Correction d’un problème d’affichage

### DIFF
--- a/content_manager/blocks.py
+++ b/content_manager/blocks.py
@@ -1037,9 +1037,7 @@ class ItemGridBlock(blocks.StructBlock):
     horizontal_align = blocks.ChoiceBlock(
         label=_("Horizontal align"), choices=GRID_HORIZONTAL_ALIGN_CHOICES, default="left", required=False
     )
-    vertical_align = blocks.ChoiceBlock(
-        label=_("Vertical align"), choices=GRID_VERTICAL_ALIGN_CHOICES, default="middle", required=False
-    )
+    vertical_align = blocks.ChoiceBlock(label=_("Vertical align"), choices=GRID_VERTICAL_ALIGN_CHOICES, required=False)
     items = ColumnBlock(label=_("Items"))
 
     class Meta:


### PR DESCRIPTION
## 🎯 Objectif
Les grilles de cartes ou de tuiles ne font plus la même hauteur sur une ligne. C'est dû au nouveau choix de l'alignement vertical, qui par défaut est centré.

## 🔍 Implémentation
- [x] Retrait de la valeur par défaut pour l'alignement vertical des grilles d'élément.
