### PR TITLE
Ajout d’un fichier robots.txt

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.urls import include, path
-from django.views.generic.base import RedirectView
+from django.views.generic.base import RedirectView, TemplateView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
@@ -16,6 +16,10 @@ urlpatterns = [
     path("documents/", include(wagtaildocs_urls)),
     path("api/v2/", api_router.urls),
     path("favicon.ico", RedirectView.as_view(url="/static/dsfr/dist/favicon/favicon.ico", permanent=True)),
+    path(
+        "robots.txt",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,0 +1,16 @@
+User-agent: *
+
+# Technical pages
+Disallow: /api/
+Disallow: /en/search/
+Disallow: /recherche/
+
+# Params
+Disallow: /*?page=*
+Disallow: /*?tag=*
+Disallow: /*?category=*
+Disallow: /*?date_from=*
+Disallow: /*?date_to=*
+
+# Sitemap
+Sitemap: {{ request.scheme }}://{{ request.get_host }}/sitemap.xml

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -6,9 +6,12 @@ Disallow: /en/search/
 Disallow: /recherche/
 
 # Params
-Disallow: /*?page=*
-Disallow: /*?tag=*
+Disallow: /*?author=*
 Disallow: /*?category=*
+Disallow: /*?source=*
+Disallow: /*?tag=*
+Disallow: /*?year=*
+Disallow: /*?page=*
 Disallow: /*?date_from=*
 Disallow: /*?date_to=*
 


### PR DESCRIPTION
## 🎯 Objectif
Le fichier `robots.txt` permet de gérer finement la façon dont les robots indexent le site. 

Exemples dans l'écosystème de l'État : 
- https://www.info.gouv.fr/robots.txt
- https://www.elysee.fr/robots.txt
- https://lasuite.numerique.gouv.fr/robots.txt
- 

## 🔍 Implémentation
- [x] Ajout du fichier et de la conf, basée sur les pages et paramètres de Sites Faciles
