### PR TITLE
Affiche des alt vides pour les tuiles

### DIFF
--- a/content_manager/templates/content_manager/blocks/tile.html
+++ b/content_manager/templates/content_manager/blocks/tile.html
@@ -52,7 +52,7 @@
           </svg>
         </div>
       {% else %}
-        <div class="fr-tile__img">{% image value.image width-80 %}</div>
+        <div class="fr-tile__img">{% image value.image width-80 alt="" %}</div>
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
## 🎯 Objectif

Accessibilité 1.2  Chaque image de décoration est-elle correctement ignorée par les technologies d’assistance ?
Sur les tuiles l'alt de l'image par défaut est le nom du fichier, ce qui donne des alt comme "icon document"

## 🔍 Implémentation

Les tuiles étant faites pour n'avoir que des pictos et donc des images qui n'apporte pas de valeur ajouté à la page on les ignore en mettant un alt vide

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images
Avant 
<img width="516" alt="Capture d’écran 2025-04-17 à 14 54 53" src="https://github.com/user-attachments/assets/56b68454-0c88-4053-9600-6003ceeb0ae9" />

Après
<img width="510" alt="Capture d’écran 2025-04-17 à 14 53 15" src="https://github.com/user-attachments/assets/1cb69f34-f331-423d-be52-852d303a0b09" />
