### PR TITLE
Correction de l’encodage de la largeur du logo

### DIFF
--- a/templates/blocks/footer.html
+++ b/templates/blocks/footer.html
@@ -16,7 +16,7 @@
         <img class="fr-footer__logo"
              src="{{ logo_img.url }}"
              alt="{{ settings.content_manager.CmsDsfrConfig.operator_logo_alt }}"
-             {% if settings.content_manager.CmsDsfrConfig.operator_logo_width >= 1 %}style="max-width:{{ settings.content_manager.CmsDsfrConfig.operator_logo_width }}rem;"{% endif %} />
+             {% if settings.content_manager.CmsDsfrConfig.operator_logo_width >= 1 %}style="max-width:{{ settings.content_manager.CmsDsfrConfig.operator_logo_width|floatformat:"1u" }}rem;"{% endif %} />
         {# L’alternative de l’image (attribut alt) doit impérativement être renseignée et reprendre le texte visible dans l’image #}
       </a>
     </div>

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -39,7 +39,7 @@
       <img class="fr-responsive-img"
            src="{{ logo_img.url }}"
            alt="{{ settings.content_manager.CmsDsfrConfig.operator_logo_alt }}"
-           {% if settings.content_manager.CmsDsfrConfig.operator_logo_width >= 1 %}style="max-width:{{ settings.content_manager.CmsDsfrConfig.operator_logo_width }}rem;"{% endif %} />
+           {% if settings.content_manager.CmsDsfrConfig.operator_logo_width >= 1 %}style="max-width:{{ settings.content_manager.CmsDsfrConfig.operator_logo_width|floatformat:"1u" }}rem;"{% endif %} />
     </div>
   {% endif %}
 {% endblock operator_logo %}


### PR DESCRIPTION
## 🎯 Objectif
Fix #120 

## 🔍 Implémentation
- [x] Ajout du filtre `|floatformat:"1u" ` (cf [doc](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#floatformat))
