### PR TITLE
Ajout d’un template tag "canonical_url"

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -37,6 +37,7 @@ DEBUG = True if os.getenv("DEBUG") == "True" else False
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "127.0.0.1,.localhost").replace(" ", "").split(",")
 
+HOST_PROTO = os.getenv("HOST_PROTO", "https")
 HOST_URL = os.getenv("HOST_URL", "localhost")
 
 INTERNAL_IPS = [
@@ -266,7 +267,7 @@ WAGTAIL_SITE_NAME = os.getenv("SITE_NAME", "Sites faciles")
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-WAGTAILADMIN_BASE_URL = f"{os.getenv('HOST_PROTO', 'https')}://{HOST_URL}"
+WAGTAILADMIN_BASE_URL = f"{HOST_PROTO}://{HOST_URL}"
 
 HOST_PORT = os.getenv("HOST_PORT", "")
 if HOST_PORT != "":

--- a/content_manager/templatetags/wagtail_dsfr_tags.py
+++ b/content_manager/templatetags/wagtail_dsfr_tags.py
@@ -44,7 +44,7 @@ def canonical_url(context):
         if site.port != 80:
             hostname = f"{hostname}:{site.port}"
     else:
-        hostname = request.path
+        hostname = request.get_host
 
     return f"{scheme}://{hostname}{request.path}"
 

--- a/content_manager/templatetags/wagtail_dsfr_tags.py
+++ b/content_manager/templatetags/wagtail_dsfr_tags.py
@@ -3,6 +3,7 @@ from django import template
 from django.conf import settings
 from django.template.context import Context
 from django.utils.html import mark_safe
+from wagtail.models import Site
 from wagtail.rich_text import RichText
 
 from content_manager.models import MegaMenu
@@ -23,6 +24,29 @@ def mega_menu(context: Context, parent_menu_id: int) -> dict:
 @register.simple_tag
 def settings_value(name):
     return getattr(settings, name, "")
+
+
+@register.simple_tag(takes_context=True)
+def canonical_url(context):
+    """
+    Make the best effort to get a canonical URL for the current page, considering that:
+    - Multiple schemes can be allowed (http vs https), but only one should be canonical
+    - Sites can answer to multiple URLs, but only one should be canonical
+    - Multiple sites can exist on the same instance
+    - Some pages are not instances of Wagtail Pages (eg. search results, 404, etc.)
+    """
+    request = context["request"]
+    scheme = settings.HOST_PROTO
+    site = Site.find_for_request(request)
+
+    if site:
+        hostname = site.hostname
+        if site.port != 80:
+            hostname = f"{hostname}:{site.port}"
+    else:
+        hostname = request.path
+
+    return f"{scheme}://{hostname}{request.path}"
 
 
 @register.filter

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load i18n static dsfr_tags wagtailuserbar wagtailsettings_tags sass_tags %}
+{% load i18n static dsfr_tags wagtailuserbar wagtailsettings_tags sass_tags wagtail_dsfr_tags %}
 
 {% get_settings %}
 {% with SiteConfig=settings.content_manager.CmsDsfrConfig %}
@@ -18,6 +18,10 @@
 
       {% block description %}
       {% endblock description %}
+
+      {% block canonical_url %}
+        <link rel="canonical" href="{% canonical_url %}" />
+      {% endblock canonical_url %}
 
       {% dsfr_favicon %}
 


### PR DESCRIPTION
## 🎯 Objectif
Comme indiqué par @sblondon dans #289 : 
> Dans le but d'améliorer le référencement, il est nécessaire d'éliminer les URL dupliquées détectées par Google Search Console. En particulier les URL suivis de paramètres sont considérées comme les pages dupliquées alors que ces paramètres n'ont pas d'effet de différenciation (par exemple les paramètres pour Matomo).

> La définition d'une URL canonique, sans ces paramètres, permet de corriger cela.

> Il n'est pas possible d'utiliser simplement request.get_full_path dans le template car, dans ce cas, les paramètres GET sont aussi affichés dans l'URL canonique. Le but de la définition de l'URL canonique est les supprimer pour que les différentes URL ne soient plus considérées comme unique mais bien comme la même page.

> L'implémentation utilisée suppose qu'il n'existe qu'un seul domaine qui fournit les pages. S'il y a plusieurs domaines (ou http et https), ils doivent tous rediriger vers le domaine de référence.

> Étant donné que l'hypothèse n'est pas forcément vraie, je comprendrai que ce ne soit pas acceptable (ou qu'il faudrait la rendre facultative par exemple).

Cette PR remplace #289 et gère les cas où plusieurs domaines ou protocoles (http vs https) fournissent la page pour donner, autant que possible, une URL canonique unique.

## 🔍 Implémentation
- [x] Ajout d’un nouveau templatetag `canonical_url` pour gérer autant que possible tous ces cas.

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
