### PR TITLE
Déplacement du bloc en-tête dans l'onglet contenu

### DIFF
--- a/content_manager/abstract.py
+++ b/content_manager/abstract.py
@@ -96,11 +96,6 @@ class SitesFacilesBasePage(Page):
     )
 
     content_panels = Page.content_panels + [
-        FieldPanel("body", heading=_("Body")),
-    ]
-
-    promote_panels = [
-        MultiFieldPanel(Page.promote_panels, _("Common page configuration")),
         MultiFieldPanel(
             [
                 FieldPanel("header_with_title"),
@@ -118,6 +113,11 @@ class SitesFacilesBasePage(Page):
             ],
             heading=_("Header options"),
         ),
+        FieldPanel("body", heading=_("Body")),
+    ]
+
+    promote_panels = [
+        MultiFieldPanel(Page.promote_panels, _("Common page configuration")),
     ]
 
     search_fields = Page.search_fields + [


### PR DESCRIPTION
## 🎯 Objectif

Faciliter la découvrabilité du bloc d’en-tête en le transférant dans l’onglet contenu

## 🔍 Implémentation

- Déplacement des champs liés à l'en-tête dans les `content_panels` 


## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
