### PR TITLE
Affichage des types de blocs du corps de page dans l'édition

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -25,3 +25,24 @@
 .public-DraftStyleDefault-unorderedListItem {
     list-style-type: disc !important;
 }
+
+/** Overriding streamfield panel block style to show block title instead of its content for greater clarity **/
+.w-panel__heading {
+    display: flex !important;
+    gap:5px;
+}
+
+.w-panel__heading .c-sf-block__type {
+    order:1;
+}
+
+.w-panel__heading .c-sf-block__title {
+    order:2;
+} 
+[aria-expanded='false'] + .w-panel__heading .c-sf-block__type::after {
+  content: ' : ';
+}
+
+[aria-expanded='false'] + .w-panel__heading .c-sf-block__type {
+  display: inline !important;
+}


### PR DESCRIPTION
## 🎯 Objectif

Amélioration de la lisibilité du back-office
Ticket SFH-503

## 🔍 Implémentation

- Ajout de CSS pour cibler les classes Wagtail permettant d'afficher le type de bloc suivi de son titre quand le bloc est replié

## ⚠️ Informations supplémentaires

A terme : proposer un changement de l'ui de ce [composant](https://github.com/wagtail/wagtail/blob/405fa76288a91e64e4e5582d0ec56d08a6920df0/wagtail/admin/templates/wagtailadmin/shared/panel.html#L28) à Wagtail

## 🖼️ Images

Comportement selon l'ouverture ou fermeture des blocs 

<img width="872" alt="Capture d’écran 2025-05-28 à 14 02 52" src="https://github.com/user-attachments/assets/7831a54d-f884-4b30-b8be-1d37c49bb236" />

