### PR TITLE
Vérification que le script de création de page ne tourne pas sur un site déjà existant

### DIFF
--- a/content_manager/management/commands/create_starter_pages.py
+++ b/content_manager/management/commands/create_starter_pages.py
@@ -17,8 +17,7 @@ ALL_ALLOWED_SLUGS = ["home", "mentions-legales", "accessibilite", "contact"]
 
 class Command(BaseCommand):
     help = """
-    Creates a series of starter pages, in order to avoid new sites having only a
-    blank "Welcome to Wagtail" page.
+    Creates a series of starter pages, in order to avoid new sites having only a blank "Welcome to Wagtail" page.
     """
 
     def add_arguments(self, parser):
@@ -27,14 +26,20 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        pictograms_exist = Image.objects.filter(title__contains="Pictogrammes DSFR").count()
-        if not pictograms_exist:
-            call_command("import_dsfr_pictograms")
-
         slugs = kwargs.get("slug")
 
         if not slugs:
+            # Only run the script on a new site or for specific slugs
+            if Page.objects.last().id > 2:
+                self.stdout.write("The site appears to already have pages, so this script won't run without params.")
+                self.stdout.write("Please run this script on a new site, or with the 'slug' parameter.")
+                return
+
             slugs = ALL_ALLOWED_SLUGS
+
+        pictograms_exist = Image.objects.filter(title__contains="Pictogrammes DSFR").count()
+        if not pictograms_exist:
+            call_command("import_dsfr_pictograms")
 
         for slug in slugs:
             if slug == "home":

--- a/content_manager/management/commands/create_starter_pages.py
+++ b/content_manager/management/commands/create_starter_pages.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         if not slugs:
             # Only run the script on a new site or for specific slugs
             if Page.objects.last().id > 2:
-                self.stdout.write("The site appears to already have pages, so this script won't run without params.")
+                self.stdout.write(self.style.NOTICE("The site appears to already have pages, so this script won't run without params."))
                 self.stdout.write("Please run this script on a new site, or with the 'slug' parameter.")
                 return
 


### PR DESCRIPTION
## 🎯 Objectif
Prépare une évolution où on tourne les mêmes commandes pour l'installation initiale et les mises à jour.

De manière plus générale, les scripts doivent être « fool proof » et pouvoir être lancés plusieurs fois sans effet négatif.

## 🔍 Implémentation
- [x] Ajout d’une vérification au lancement du script s’il est lancé sans paramètre (permet de créer quand même une page spécifique si d’autres ont déjà été crées à la main)

