### PR TITLE
Renommage de la locale 'French' vers 'Français'

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -202,7 +202,7 @@ WAGTAIL_I18N_ENABLED = True
 
 WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
     ("en", "English"),
-    ("fr", "French"),
+    ("fr", "Français"),
 ]
 
 LOCALE_PATHS = ["locale"]


### PR DESCRIPTION
## 🎯 Objectif
Affichage des langues dans leur propre langue plutôt qu'en anglais systématiquement.

## 🔍 Implémentation
- [x] Changement d’une variable dans `config/settings.py`

## 🖼️ Images
![Capture d’écran du 2025-06-03 18-39-00](https://github.com/user-attachments/assets/b8142800-b293-4e88-b1ea-1ce6a6fbc839)
