### PR TITLE
Ajout de recettes just pour auditer le code

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,11 +18,6 @@ default:
 collectstatic:
     {{docker_cmd}} {{uv_run}} python manage.py collectstatic --noinput
 
-coverage app="":
-    {{uv_run}} coverage run --source='.' manage.py test {{app}}
-    {{uv_run}} coverage html
-    firefox htmlcov/index.html
-
 createsuperuser:
     {{docker_cmd}} {{uv_run}} python manage.py createsuperuser
 
@@ -111,6 +106,12 @@ cloc:
     for d in "blog" "content_manager" "dashboard" "events" "forms" "proconnect" "templates" ; do \
     (cd "$d" && echo "$d" && cloc --vcs git); \
     done
+
+# Evaluate test coverage then generate and open a HTML report
+coverage app="":
+    {{uv_run}} coverage run --source='.' manage.py test {{app}}
+    {{uv_run}} coverage html
+    firefox htmlcov/index.html
 
 # Gives a rough estimate of the number of internal and external routes
 routes-count:

--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ web-prompt:
 
 # Count lines of code per app
 cloc:
-    for d in "blog" "content_manager" "dashboard" "events" "forms" "proconnect" "templates" ; do \
+    @for d in "blog" "content_manager" "dashboard" "events" "forms" "proconnect" "templates" ; do \
     (cd "$d" && echo "$d" && cloc --vcs git); \
     done
 

--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ web-prompt:
 
 # Count lines of code per app
 cloc:
-    @for d in "blog" "content_manager" "dashboard" "events" "forms" "proconnect" "templates" ; do \
+    @for d in "config" "blog" "content_manager" "dashboard" "events" "forms" "proconnect" "templates" ; do \
     (cd "$d" && echo "$d" && cloc --vcs git); \
     done
 

--- a/justfile
+++ b/justfile
@@ -115,9 +115,9 @@ coverage app="":
 
 # Gives a rough estimate of the number of internal and external routes
 routes-count:
-    @{{uv_run}} python manage.py shell -c "from django.urls import get_resolver ; \
+    @{{uv_run}} python manage.py shell -v 0 -c "from django.urls import get_resolver ; \
     routes = set(v[1] for k,v in get_resolver().reverse_dict.items()) ; \
     print('Total: ' + str(len(routes))) ; \
     print('Internal: ' + str(len(list(filter(lambda k: '-admin' in k, routes))) - 3)) ; \
     print('External: ' + str(len(list(filter(lambda k: '-admin' not in k, routes))) + 3)) ;"
-    # (manually adjusting for login/logout and password reset routes)
+    @# (manually adjusting for login/logout and password reset routes)


### PR DESCRIPTION
## 🎯 Objectif
Pour la préparation de l'audit de sécurité, nous avons dû répondre à un questionnaire. Ajout de recettes standardisées pour le nombre de lignes de code par application et pour le nombre de routes internes et externes.

## 🔍 Implémentation
- [x] Ajout de la recette `just cloc`
- [x] Ajout de la recette `just routes-count`
- [x] Réorganisation du `justfile`

## ⚠️ Informations supplémentaires
Pour la recette `just cloc`, cloc doit être installé sur la machine (cf. [doc](https://github.com/AlDanial/cloc?tab=readme-ov-file#install-via-package-manager))

## 🖼️ Images
<img width="1081" height="758" alt="Capture d’écran du 2025-07-22 12-38-26" src="https://github.com/user-attachments/assets/c0bfdacc-2efd-4781-8e03-b6831fb0269d" />

