### PR TITLE
Add blue and white text color features to rich text editor

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -292,6 +292,8 @@ WAGTAIL_RICHTEXT_FIELD_FEATURES = [
     "document-link",
     "image",
     "embed",
+    "blue_text",
+    "white_text",
 ]
 
 WAGTAILEMBEDS_RESPONSIVE_HTML = True

--- a/content_manager/constants.py
+++ b/content_manager/constants.py
@@ -83,6 +83,8 @@ LIMITED_RICHTEXTFIELD_FEATURES = [
     "superscript",
     "subscript",
     "strikethrough",
+    "blue_text",
+    "white_text",
 ]
 
 LIMITED_RICHTEXTFIELD_FEATURES_WITHOUT_LINKS = [
@@ -91,6 +93,8 @@ LIMITED_RICHTEXTFIELD_FEATURES_WITHOUT_LINKS = [
     "superscript",
     "subscript",
     "strikethrough",
+    "blue_text",
+    "white_text",
 ]
 
 LINK_SIZE_CHOICES = [

--- a/content_manager/wagtail_hooks.py
+++ b/content_manager/wagtail_hooks.py
@@ -1,0 +1,51 @@
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail import hooks
+from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
+
+
+@hooks.register("register_rich_text_features")
+def register_text_colors(features):
+    """
+    Register text color features: blue and white (black is default)
+    """
+    colors = [
+        {
+            "feature_name": "blue_text",
+            "type": "BLUETEXT",
+            "label": "🔵",
+            "description": "Texte bleu",
+            "color": "#000091",
+            "css_class": "cmsfr-text--blue",
+        },
+        {
+            "feature_name": "white_text",
+            "type": "WHITETEXT",
+            "label": "⚪",
+            "description": "Texte blanc",
+            "color": "#ffffff",
+            "css_class": "cmsfr-text--white",
+        },
+    ]
+
+    for color_config in colors:
+        control = {
+            "type": color_config["type"],
+            "label": color_config["label"],
+            "description": color_config["description"],
+            "icon": "pilcrow",
+            "style": {"color": color_config["color"]},
+        }
+
+        features.register_editor_plugin(
+            "draftail", color_config["feature_name"], draftail_features.InlineStyleFeature(control)
+        )
+
+        db_conversion = {
+            "from_database_format": {
+                f'span[class="{color_config["css_class"]}"]': InlineStyleElementHandler(color_config["type"])
+            },
+            "to_database_format": {"style_map": {color_config["type"]: f'span class="{color_config["css_class"]}"'}},
+        }
+
+        features.register_converter_rule("contentstate", color_config["feature_name"], db_conversion)
+        features.default_features.append(color_config["feature_name"])

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -85,3 +85,10 @@
         order: 2
     }
 }
+
+.cmsfr-text--blue {
+  color: var(--text-active-blue-france) !important;
+}
+.cmsfr-text--white {
+  color: var(--grey-1000-50) !important;
+}


### PR DESCRIPTION
## 🎯 Objectif

Ajouter la possibilité d'écrire du texte noir, bleu et blanc depuis l'éditeur

## 🔍 Implémentation

Ajoute un wagtail_hook pour ajouter un bouton bleu et un bouton blanc

## 🖼️ Images

<img width="246" height="159" alt="Screenshot 2025-07-24 at 16 30 27" src="https://github.com/user-attachments/assets/77b67adb-ad0e-474a-9859-db3eb6ed4c3e" />
