### PR TITLE
ci: publish docker image with release tag

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "**"
+    tags:
+      - "v*.*.*"
 
 jobs:
   docker:
@@ -21,12 +23,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
+      - name: Extract tag without leading v
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "TAG_NO_V=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
             ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/sites-faciles:${{ env.GITHUB_REF_SLUG }}
-            ${{ github.ref_name == 'main' && format('ghcr.io/{0}/sites-faciles:latest', env.GITHUB_REPOSITORY_OWNER_PART_SLUG) || '' }}
+            ${{ env.TAG_NO_V && format('ghcr.io/{0}/sites-faciles:latest', env.GITHUB_REPOSITORY_OWNER_PART_SLUG) || '' }}
+            ${{ env.TAG_NO_V && format('ghcr.io/{0}/sites-faciles:{1}', env.GITHUB_REPOSITORY_OWNER_PART_SLUG, env.TAG_NO_V) || '' }}
           cache-from: type=registry,ref=ghcr.io/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/sites-faciles:${{ env.GITHUB_REF_SLUG }}
           cache-to: type=inline


### PR DESCRIPTION
## 🎯 Objectif

Amélioration de la CI/CD de publication des images docker. Cette modification permet de publier les images liées aux release git et ainsi de suivre les bonnes pratique en terme de déploiement (une image `latest` ne devrait jamais être utilisée en production car c'est un tag mutable qui évolue dans le temps et ne garanti pas de stabilité dans le temps.

## 🔍 Implémentation

- Lorsqu'un tag git est créé, publie une image docker réutilisant ce dernier (sans le `v`).
- N'ajoute le tag `latest` que s'il s'agit d'un nouveau tag git (`latest` devrait représenter la dernière version stable, le tag `main` existe déjà pour avoir la dernière version de la branche principale).

## ⚠️ Informations supplémentaires

\- 

## 🏕 Amélioration continue

A chaque publication d'une nouvelle image `sites-faciles`, il serait intéressant de créer un workflow qui propose automatiquement une mise à jour du [futur Helm chart](https://github.com/numerique-gouv/helm-charts/pull/58) de déploiement (pour Kubernetes).

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
