### PR TITLE
Lancer la commande set_config quand la base de données est restaurée

### DIFF
--- a/justfile
+++ b/justfile
@@ -179,6 +179,7 @@ restore-local:
 [group('Dev DB and medias management')]
 restore-local-db:
     cd scripts && bash restore_local_db.sh
+    {{docker_cmd}} {{uv_run}} python manage.py set_config
 
 # Restore the last local medias backup
 [group('Dev DB and medias management')]
@@ -189,11 +190,13 @@ restore-local-medias:
 [group('Dev DB and medias management')]
 restore-prod:
     cd scripts && bash restore_prod_db.sh && bash restore_prod_medias.sh
+    {{docker_cmd}} {{uv_run}} python manage.py set_config
 
 # Restore the last downloaded backup of the production database
 [group('Dev DB and medias management')]
 restore-prod-db:
     cd scripts && bash restore_prod_db.sh
+    {{docker_cmd}} {{uv_run}} python manage.py set_config
 
 # Restore the last downloaded media files
 [group('Dev DB and medias management')]


### PR DESCRIPTION
## 🎯 Objectif
Permet que le site par défaut soit conforme aux variables d'environnement configurées après une restauration de la base de données.

## 🔍 Implémentation
- [x] Ajout de la commande aux recettes just concernées

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
