### PR TITLE
Rendre settings.USE_X_FORWARDED_HOST configurable

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -31,7 +31,7 @@ def getenv_bool(key: str, default: bool):
         value = os.environ[key]
     except KeyError:
         return default
-    return value.casefold() in {"1", "True"}
+    return value.casefold() in ["1", "true"]
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
## 🎯 Objectif

Permettre de configurer l’application pour lire le header `X-Forwarded-Host` défini par un _reverse proxy_.

## 🔍 Implémentation

- Création d’un auxiliaire pour lire une valeur booléenne depuis l’environnement.
- Définition du _setting_ [`USE_X_FORWARDED_HOST`](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-USE_X_FORWARDED_HOST) de django, en gardant sa valeur par défaut (`False`).

## ⚠️ Informations supplémentaires

Le _setting_ `ALLOWED_HOST` permet d’éviter qu’un attaquant n’injecte une valeur inattendue pour le `X-Forwarded-Host`.
