### PR TITLE
Corrige l'alignement des boutons sur les entêtes

### DIFF
--- a/content_manager/templates/content_manager/heros/_hero_buttons.html
+++ b/content_manager/templates/content_manager/heros/_hero_buttons.html
@@ -1,5 +1,5 @@
 {% with value.buttons.0.icon_side as icons_side %}
-  <ul class="fr-btns-group fr-btns-group--inline-lg cmsfr-hero-btns--center {% if icons_side == 'fr-btn--icon-left' %} fr-btns-group--icon-left{% elif icons_side == 'fr-btn--icon-right' %} fr-btns-group--icon-right {% endif %}">
+  <ul class="cmsfr-hero-btns {% if value.text_content.position == 'left' %} cmsfr-hero-btns--left {% elif value.text_content.position == 'right' %} cmsfr-hero-btns--right {% else %} cmsfr-hero-btns--center {% endif %} fr-btns-group fr-btns-group--inline-lg {% if icons_side == 'fr-btn--icon-left' %} fr-btns-group--icon-left {% elif icons_side == 'fr-btn--icon-right' %} fr-btns-group--icon-right {% endif %}">
     {% for button in value.buttons %}
       <li>{% include "content_manager/blocks/button.html" with button=button %}</li>
     {% endfor %}


### PR DESCRIPTION
## 🎯 Objectif

Correction de l'alignement et du style qui avait sauté sur les entêtes. 

## 🔍 Implémentation

- On remet le style appliqué lors de la PR des entêtes 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

<img width="1435" height="763" alt="Capture d’écran 2025-11-18 à 17 20 17" src="https://github.com/user-attachments/assets/2ea8318c-18f7-48ca-803b-b214847603e6" />

