### PR TITLE
Corrige les erreurs dans les composants articles / evenements récents

### DIFF
--- a/content_manager/templates/content_manager/blocks/blog_recent_entries.html
+++ b/content_manager/templates/content_manager/blocks/blog_recent_entries.html
@@ -94,11 +94,10 @@
               {% endif %}
             </div>
           </div>
-          {% firstof post.header_image post.image as image %}
-          {% if image %}
+          {% if post.cover %}
             <div class="fr-card__header">
               <div class="fr-card__img">
-                <img class="fr-responsive-img" src="{{ image.file.url }}" alt="">
+                <img class="fr-responsive-img" src="{{ post.cover.file.url }}" alt="">
               </div>
             </div>
           {% endif %}

--- a/content_manager/templates/content_manager/blocks/events_recent_entries.html
+++ b/content_manager/templates/content_manager/blocks/events_recent_entries.html
@@ -94,11 +94,10 @@
               {% endif %}
             </div>
           </div>
-          {% firstof post.header_image post.image as image %}
-          {% if image %}
+          {% if post.cover %}
             <div class="fr-card__header">
               <div class="fr-card__img">
-                <img class="fr-responsive-img" src="{{ image.file.url }}" alt="">
+                <img class="fr-responsive-img" src="{{ post.cover.file.url }}" alt="">
               </div>
             </div>
           {% endif %}


### PR DESCRIPTION
## 🎯 Objectif

Corrige une régressions suite à l'insertion de la property `cover` dans les composants de remontées de contenus automatique (Articles récents du blog / Evenements à  venir) 
## 🔍 Implémentation

- Appel de la property qui récupère les nouveaux en-têtes ou l'ancien champs d'image 


## 🖼️ Images
<img width="1053" height="797" alt="Capture d’écran 2025-11-24 à 12 03 32" src="https://github.com/user-attachments/assets/539c787a-901c-4d8a-8bd6-874f4267cb40" />


