### PR TITLE
Corrige l'alignement des boutons sur l'entête configurable

### DIFF
--- a/content_manager/templates/content_manager/heros/old_hero.html
+++ b/content_manager/templates/content_manager/heros/old_hero.html
@@ -1,14 +1,14 @@
 {% load static wagtailcore_tags wagtailimages_tags %}
 {% if value.header_image or value.header_color_class %}
   {% image value.header_image fill-1200x350 as bg_img %}
-  <div class="cmsfr-hero cmsfr-hero-position__center {% if value.header_large %}cmsfr-hero-large{% endif %}{% if value.header_darken %} cmsfr-background-dark {% endif %}"
+  <div class="cmsfr-hero cmsfr-hero-position__center cmsfr-hero-column {% if value.header_large %}cmsfr-hero-large{% endif %}{% if value.header_darken %} cmsfr-background-dark {% endif %}"
        style="{% if value.header_image %}background-image: {% if value.header_darken %}linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.7)),{% endif %}url({{ bg_img.url }});
               {% elif value.header_color_class %}background-color: var(--background-alt-{{ value.header_color_class }});
               {% endif %} min-height: 350px">
     {% if value.header_with_title or value.header_cta_buttons or value.header_cta_link and value.header_cta_label %}
       <div class="fr-container fr-py-8w">
         <div class="fr-grid-row fr-grid-row--gutters">
-          <div class="fr-col fr-col-12{% if not value.header_large %}fr-col-md-6{% endif %}">
+          <div class="fr-col  {% if not value.header_large %}fr-col-md-6{% else %} fr-col-12 cmsfr-hero-column {% endif %}">
             {% if value.header_with_title %}
               <h1 {% if block.value.large %}class="fr-display--sm"{% endif %}>
                 {{ page.title }}


### PR DESCRIPTION
## 🎯 Objectif

- Les boutons ne sont pas alignés quand le titre est centré sur l'entête configurable.

Bugfix 

## 🔍 Implémentation

- ajout de classe CSS existante pour corriger ce bug

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

<img width="1426" height="319" alt="Capture d’écran 2026-03-26 à 16 37 22" src="https://github.com/user-attachments/assets/0060c683-2fe6-491c-815d-b90ad71843c0" />
<img width="1435" height="317" alt="Capture d’écran 2026-03-26 à 16 37 28" src="https://github.com/user-attachments/assets/ab66464e-8246-4b33-91ac-bc29aae1f579" />
