### PR TITLE
Optimisation des requêtes - Panneau des tutoriels Back-office

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -50,19 +50,26 @@ class TutorialsPanel(Component):
                     "https://sites.beta.gouv.fr/api/v2/pages/",
                     params={
                         "child_of": 107,
-                        "fields": "title,preview_image_render,html_url",
                     },
                     timeout=5,
                 )
                 res.raise_for_status()
-                tutorials = [
-                    {
-                        "title": page["title"],
-                        "image": page["preview_image_render"]["full_url"],
-                        "url": page["meta"]["html_url"],
-                    }
-                    for page in res.json()["items"]
-                ]
+                tutorials = []
+                for page in res.json()["items"]:
+                    page_res = requests.get(
+                        f'https://sites.beta.gouv.fr/api/v2/pages/{page["id"]}/',
+                        params={"fields": "title,preview_image_render,-body"},
+                        timeout=5,
+                    )
+                    page_res.raise_for_status()
+                    page_data = page_res.json()
+                    tutorials.append(
+                        {
+                            "title": page_data["title"],
+                            "image": page_data["preview_image_render"]["full_url"],
+                            "url": page_data["meta"]["html_url"],
+                        }
+                    )
             except requests.RequestException:
                 tutorials = []
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,7 +1,6 @@
-import json
-
 import requests
 from django.contrib.admin.utils import quote
+from django.core.cache import cache
 from django.urls import reverse
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.ui.components import Component
@@ -39,34 +38,35 @@ shortcuts_panel = ShortcutsPanel()
 
 class TutorialsPanel(Component):
     order = 300
+    CACHE_KEY = "tutorials_panel"
+    CACHE_TIMEOUT = 60 * 60 * 24 * 7
 
     def get_context_data(self, parent_content=None):
+        tutorials = cache.get(self.CACHE_KEY)
 
-        try:
-            res = requests.get(
-                "https://sites.beta.gouv.fr/api/v2/pages/?child_of=107",
-                timeout=30,
-            )
-            res.raise_for_status()
-            data = res.json()
-            tutorial_pages = [{"id": page["id"]} for page in data["items"]]
-            tutorials = []
-            for page_id in tutorial_pages:
-                page = json.loads(
-                    requests.get(
-                        f'https://sites.beta.gouv.fr/api/v2/pages/{page_id["id"]}/?fields=title,preview_image_render,-body'
-                    ).text
+        if tutorials is None:
+            try:
+                res = requests.get(
+                    "https://sites.beta.gouv.fr/api/v2/pages/",
+                    params={
+                        "child_of": 107,
+                        "fields": "title,preview_image_render,html_url",
+                    },
+                    timeout=5,
                 )
-                tutorials.append(
+                res.raise_for_status()
+                tutorials = [
                     {
                         "title": page["title"],
                         "image": page["preview_image_render"]["full_url"],
                         "url": page["meta"]["html_url"],
                     }
-                )
-        except requests.RequestException:
-            tutorials = []
+                    for page in res.json()["items"]
+                ]
+            except requests.RequestException:
+                tutorials = []
 
+            cache.set(self.CACHE_KEY, tutorials, self.CACHE_TIMEOUT)
         return {"tutorials": tutorials}
 
     template_name = "wagtailadmin/home/panels/_tutorials.html"

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -39,7 +39,7 @@ shortcuts_panel = ShortcutsPanel()
 class TutorialsPanel(Component):
     order = 300
     CACHE_KEY = "tutorials_panel"
-    CACHE_TIMEOUT = 60 * 60 * 24 * 7
+    CACHE_TIMEOUT = 60 * 60 * 24 * 7  # Cache for one week
 
     def get_context_data(self, parent_content=None):
         tutorials = cache.get(self.CACHE_KEY)


### PR DESCRIPTION
## 🎯 Objectif

Le panneau des tutoriels fait des requêtes HTTP à chaque chargement du back-office et provoque des ralentissements sur le site vitrine. 
 

## 🔍 Implémentation

- Ajout de cache d'une semaine sur le panneau pour éviter la charge 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
