### PR TITLE
Make restore scripts MACOS-compatible

### DIFF
--- a/scripts/restore_local_db.sh
+++ b/scripts/restore_local_db.sh
@@ -16,7 +16,7 @@ fi
 
 cd ${BACKUP_DIR}
 
-BACKUP_FILE=`ls sites-conformes-local-db-*.sql.gz -c | head -1`
+BACKUP_FILE=`ls -c sites-conformes-local-db-*.sql.gz | head -1`
 
 echo "Restoring database ${DATABASE_NAME} with backup ${BACKUP_FILE}"
 

--- a/scripts/restore_local_medias.sh
+++ b/scripts/restore_local_medias.sh
@@ -15,11 +15,11 @@ if [[ -z "$BACKUP_DIR" ]]; then
     exit 1
 fi
 
-MEDIA_BACKUP_FILE=`ls ${BACKUP_DIR}/sites-conformes-local-medias-*.tar.gz -c | head -1`
+MEDIA_BACKUP_FILE=`ls -c ${BACKUP_DIR}/sites-conformes-local-medias-*.tar.gz | head -1`
 BASE_PATH="${SCRIPT_DIR}/.."
 
 echo "Moving media files from ${MEDIA_BACKUP_FILE} to ${MEDIA_ROOT:=medias}"
 
 cd ${BASE_PATH}
 echo `pwd`
-rm ${MEDIA_ROOT}/* -rf && tar xvzf ${MEDIA_BACKUP_FILE}
+rm -rf ${MEDIA_ROOT}/* && tar xvzf ${MEDIA_BACKUP_FILE}

--- a/scripts/restore_prod_db.sh
+++ b/scripts/restore_prod_db.sh
@@ -17,10 +17,10 @@ fi
 
 cd ${BACKUP_DIR}
 
-TAR_FILE=`ls *_${PROD_DB_NAME}.tar.gz -c | head -1`
+TAR_FILE=`ls -c *_${PROD_DB_NAME}.tar.gz | head -1`
 tar xzf ${TAR_FILE}
 
-BACKUP_FILE=`ls *_${PROD_DB_NAME}.pgsql -c | head -1`
+BACKUP_FILE=`ls -c *_${PROD_DB_NAME}.pgsql | head -1`
 
 echo "Restoring database ${DATABASE_NAME} with backup ${BACKUP_FILE}"
 

--- a/scripts/restore_prod_medias.sh
+++ b/scripts/restore_prod_medias.sh
@@ -20,6 +20,6 @@ MEDIA_BACKUP_DIR="${BACKUP_DIR}/sites-conformes-prod-medias/"
 echo "Moving media files from ${MEDIA_BACKUP_DIR} to ${MEDIA_ROOT:=medias}"
 
 cd ${SCRIPT_DIR}
-rm ../${MEDIA_ROOT}/* -rf
+rm -rf ../${MEDIA_ROOT}/*
 
 cp -rp ${MEDIA_BACKUP_DIR}/* ../${MEDIA_ROOT}/


### PR DESCRIPTION
## 🎯 Objectif

Rendre les scripts suivants fonctionnels sur macos : 
restore_local_db.sh
restore_local_medias.sh
restore_prod_db.sh
restore_prod_medias.sh

Actuellement ils ne fonctionnent pas sur MACOS, parce que certaines commandes ont les flags apres l'argument principal (c'est ok pour linux, mais pas pour macos)

## 🔍 Implémentation

Cette PR met les flags à la fin pour que les scripts run sur macos. Tout petit fix !