### PR TITLE
Renommer les dossiers de media pour faciliter les scripts de récupération

### DIFF
--- a/scripts/descend_prod_medias.sh
+++ b/scripts/descend_prod_medias.sh
@@ -14,7 +14,12 @@ if [[ -z "$BACKUP_DIR" ]]; then
     exit 1
 fi
 
-MEDIA_BACKUP_DIR="${BACKUP_DIR}/sites-conformes-prod-medias/"
+if [[ -z "$PROD_APP" ]]; then
+    echo "Please set PROD_APP" 1>&2
+    exit 1
+fi
+
+MEDIA_BACKUP_DIR="${BACKUP_DIR}/${PROD_APP}-prod-medias/"
 
 # Create the backup directory if it doesn't exist
 test -d ${MEDIA_BACKUP_DIR} || mkdir -p ${MEDIA_BACKUP_DIR}

--- a/scripts/restore_prod_medias.sh
+++ b/scripts/restore_prod_medias.sh
@@ -15,7 +15,7 @@ if [[ -z "$BACKUP_DIR" ]]; then
     exit 1
 fi
 
-MEDIA_BACKUP_DIR="${BACKUP_DIR}/sites-conformes-prod-medias/"
+MEDIA_BACKUP_DIR="${BACKUP_DIR}/${PROD_APP}-prod-medias/"
 
 echo "Moving media files from ${MEDIA_BACKUP_DIR} to ${MEDIA_ROOT:=medias}"
 


### PR DESCRIPTION
## 🎯 Objectif

Pour les scripts scripts/descend_prod_medias.sh et scripts/restore_prod_medias.sh, le dossier dans lequel sont stockés les medias est : `${BACKUP_DIR}/sites-conformes-prod-medias/`
Lorsqu'on a plusieurs sites conformes (prod et test par dans mon cas) je ne sais plus lequel est lequel. 

Pour éviter les confusions je propose de l'appeler : `${BACKUP_DIR}/${PROD_APP}-prod-medias/` (la variable PROD_APP est déja présente dans les autres scripts du même dir)
