### PR TITLE
fil d'ariane: rendre le dernier item focusable

### DIFF
--- a/content_manager/templates/content_manager/blocks/breadcrumbs.html
+++ b/content_manager/templates/content_manager/blocks/breadcrumbs.html
@@ -27,11 +27,11 @@
             </li>
           {% endfor %}
           <li>
-            <a class="fr-breadcrumb__link" aria-current="page">{{ extra_breadcrumbs.current|truncatewords:6 }}</a>
+            <a class="fr-breadcrumb__link" href="#" aria-current="page">{{ extra_breadcrumbs.current|truncatewords:6 }}</a>
           </li>
         {% else %}
           <li>
-            <a class="fr-breadcrumb__link" aria-current="page">{{ self.title|truncatewords:6 }}</a>
+            <a class="fr-breadcrumb__link" href="#" aria-current="page">{{ self.title|truncatewords:6 }}</a>
           </li>
         {% endif %}
       </ol>


### PR DESCRIPTION
## 🎯 Objectif

Suite à notre audit RGAA, on nous a remonté que le dernier élément du fil d'Ariane était rendu via une balise <a> sans attribut href, ce qui le rend non atteignable au clavier (RGAA 7.1) et non identifié comme un lien par les technologies d'assistance. 

## 🔍 Implémentation


L'ajout de href="#" et de aria-current="page" suit le pattern de référence du W3C ARIA pour le composant breadcrumb : https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
