### PR TITLE
Ajout du versionning via GitHub Actions + publication PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 # See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 # for a detailed guide.
 #
-# Triggers only on GitHub Release publish. The release branch (e.g. v3.1.1-namespaced-folder)
-# is the working branch — actual PyPI uploads happen when a release is cut.
+# Triggers only on GitHub Release publish. The release tag IS the package
+# version: cutting a release named e.g. v4.0.0 publishes sites-conformes==4.0.0
+# to PyPI. There is no manual version bump in pyproject.toml.
 name: Publish to PyPI
 
 on:
@@ -25,15 +26,22 @@ jobs:
       - name: Install build dependencies
         run: python -m pip install --upgrade build
 
+      - name: Resolve version from release tag
+        # Strip a leading "v" so v4.0.0 becomes a PEP 440 version 4.0.0.
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "Publishing version: ${VERSION}"
+          printf '__version__ = "%s"\n' "${VERSION}" > sites_conformes/_version.py
+
       - name: Build package
-        working-directory: ./sites_conformes
         run: python -m build
 
       - name: Upload dist
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: ./sites_conformes/dist
+          path: dist
 
   publish:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,17 @@ WORKDIR $APP_DIR
 COPY pyproject.toml uv.lock ./
 # Deploy in the global env of the container instead of a uv-specific venv
 ENV UV_PROJECT_ENVIRONMENT="/usr/local/"
-RUN uv sync --locked
+# Install dependencies only. The project itself can't be built yet: its version
+# is dynamic (resolved from sites_conformes/_version.py via setuptools' attr
+# directive), and that module hasn't been copied at this layer. Installing deps
+# separately also keeps this layer cached across source-only changes.
+RUN uv sync --locked --no-install-project
 
 COPY --chown=app:app . .
+
+# Now the source (incl. sites_conformes/_version.py) is present, so the dynamic
+# version resolves and the project can be installed editable into the env.
+RUN uv sync --locked
 
 RUN uv run python manage.py collectstatic --no-input
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
 name = "sites-conformes"
-# This is the packagified-release version, decoupled from upstream's tag.
-# Upstream `v3.2.0` is the source we fork from; we publish as `4.0.0` because
-# the packaging changes are large enough to warrant a major bump for consumers.
-version = "4.0.0rc1"
+# Version is driven by the GitHub Release tag at publish time. See
+# .github/workflows/publish.yml, which writes sites_conformes/_version.py
+# from github.event.release.tag_name (stripped of a leading "v").
+# The committed _version.py value is the local/dev fallback.
+dynamic = ["version"]
 description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l’État, accessible et responsive"
 authors = [
     { name = "Sites Conformes dev team", email = "contact@sites.beta.gouv.fr" }
@@ -58,6 +59,9 @@ dev = [
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = { attr = "sites_conformes._version.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/sites_conformes/_version.py
+++ b/sites_conformes/_version.py
@@ -1,0 +1,3 @@
+# Overwritten by .github/workflows/publish.yml at release time from the
+# GitHub Release tag. The committed value here is the local/dev fallback.
+__version__ = "0.0.0.dev0"

--- a/uv.lock
+++ b/uv.lock
@@ -1652,7 +1652,6 @@ wheels = [
 
 [[package]]
 name = "sites-conformes"
-version = "4.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## 🎯 Objectif

Versionning dynamique 

## 🔍 Implémentation

- on génère le numéro de version dans gh actions basé sur la release publié 
- on l'écrit localement dans un fichier python (de placeholder)
- on publie sur la base de cette version 

