### PR TITLE
Corrige l'erreur 500 sur l'image de fond 

### DIFF
--- a/sites_conformes/core/blocks/heros.py
+++ b/sites_conformes/core/blocks/heros.py
@@ -207,7 +207,7 @@ class HeroBackgroundImageBlock(blocks.StructBlock):
             raise StructBlockValidationError(block_errors=errors)
 
         if selected_background_type == "color":
-            value["image"] = None
+            value["image"] = {}
         elif selected_background_type == "image":
             value["background_color"] = None
 


### PR DESCRIPTION
## 🎯 Objectif

<img width="1510" height="441" alt="Capture d’écran 2026-06-15 à 12 30 12" src="https://github.com/user-attachments/assets/94ccfb23-86ad-411e-9271-51091468478c" />

- Résoud une erreur dans la fonction `clean` des entêtes avec fond 

## 🔍 Implémentation

- Instancier un dict plutôt que `None` lorsqu'on retire une image pour mettre une couleur de fond 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
