### PR TITLE
Corriger une erreur 500 à la traduction d'une page (ImageBlock imbriqué)

### DIFF
--- a/sites_conformes/core/apps.py
+++ b/sites_conformes/core/apps.py
@@ -6,6 +6,9 @@ class ContentManagerConfig(AppConfig):
     name = "sites_conformes.core"
     label = "sites_conformes_core"
 
+    # Monkey patches are applied in the ready() method of the AppConfig, which is called when the app is loaded.
+    # This ensures that the patches are applied before any code that relies on the patched behavior is executed.
+    # To be removed once wagtail-localize fixes the bug in handle_image_block (https://github.com/wagtail/wagtail-localize/pull/935)
     def ready(self):
         from .monkey_patches import patch_wagtail_localize_handle_image_block
 

--- a/sites_conformes/core/apps.py
+++ b/sites_conformes/core/apps.py
@@ -5,3 +5,8 @@ class ContentManagerConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "sites_conformes.core"
     label = "sites_conformes_core"
+
+    def ready(self):
+        from .monkey_patches import patch_wagtail_localize_handle_image_block
+
+        patch_wagtail_localize_handle_image_block()

--- a/sites_conformes/core/monkey_patches.py
+++ b/sites_conformes/core/monkey_patches.py
@@ -1,0 +1,58 @@
+"""
+Monkey patches applied to third-party libraries at startup.
+
+Applied from ``ContentManagerConfig.ready()``.
+"""
+
+from wagtail import blocks
+from wagtail_localize.segments.extract import StreamFieldSegmentExtractor
+
+
+def patch_wagtail_localize_handle_image_block():
+    """
+    Fix a crash in wagtail-localize when translating a page that contains an
+    ``ImageBlock`` nested two struct levels deep, e.g. the ``hero_text_wide_image``
+    block (hero -> ``image`` struct -> ``image`` ImageBlock).
+
+    ``handle_struct_block`` only threads the ``raw_value`` one level down
+    (``raw_value["value"].get(field_name)``), so a doubly-nested ImageBlock
+    receives ``raw_value=None``. ``handle_image_block`` then calls
+    ``raw_value.get("type")`` without guarding against ``None``, raising
+    ``AttributeError: 'NoneType' object has no attribute 'get'`` (the surrounding
+    ``except (KeyError, TypeError)`` does not catch ``AttributeError``). This
+    happens regardless of whether an image is actually set.
+
+    Bug still present in wagtail-localize main as of 1.13.1.
+    See extract.py::StreamFieldSegmentExtractor.handle_image_block.
+    """
+
+    def handle_image_block(self, block, image_block_value, raw_value=None):
+        segments = []
+
+        for field_name, block_type in block.child_blocks.items():
+            if raw_value and raw_value.get("type") and raw_value.get("value"):
+                # for top-level ImageBlock, raw_value has a
+                # {"type": "field_name", "value": {"image": X, "alt_text": "", "caption": ""}} format.
+                # whereas if the ImageBlock is part of a StructBlock, ListBlock or StreamBlock, we
+                # only get the "value" part.
+                raw_value = raw_value.get("value")
+
+            try:
+                block_raw_value = raw_value.get(field_name)
+                block_value = image_block_value if field_name == "image" else block_raw_value
+            except (KeyError, TypeError, AttributeError):
+                # e.g. raw_value is None (image block with no image), or it is from a chooser
+                block_raw_value = None
+                block_value = None
+
+            if isinstance(block_type, blocks.CharBlock) and block_value is None:
+                block_value = ""
+
+            segments.extend(
+                segment.wrap(field_name)
+                for segment in self.handle_block(block_type, block_value, raw_value=block_raw_value)
+            )
+
+        return segments
+
+    StreamFieldSegmentExtractor.handle_image_block = handle_image_block

--- a/sites_conformes/core/tests/test_translation.py
+++ b/sites_conformes/core/tests/test_translation.py
@@ -1,0 +1,64 @@
+from wagtail.models import Page
+from wagtail.rich_text import RichText
+from wagtail.test.utils import WagtailPageTestCase
+from wagtail_localize.segments.extract import extract_segments
+
+from sites_conformes.core.models import ContentPage
+from sites_conformes.core.utils import import_image
+
+
+class TranslationImageBlockExtractionTestCase(WagtailPageTestCase):
+    """
+    Regression test for a 500 when submitting a page for translation
+    (POST /cms-admin/localize/submit/page/<id>/).
+
+    wagtail-localize's StreamFieldSegmentExtractor.handle_image_block crashes
+    with "'NoneType' object has no attribute 'get'" when an ImageBlock is
+    nested two struct levels deep, e.g. the "hero_text_wide_image" block:
+        hero_text_wide_image -> image (HeroImageBlockWithRatioWidth) -> image (ImageBlock)
+    handle_struct_block only threads the raw_value one level down, so the
+    ImageBlock receives raw_value=None and the code calls None.get(...).
+    This happens regardless of whether an image is actually set; the page
+    renders fine but translation extraction blows up.
+
+    Fixed by sites_conformes.core.monkey_patches (applied in apps.ready()).
+    """
+
+    def setUp(self):
+        home = Page.objects.get(slug="home")
+        image = import_image("sites_conformes/static/artwork/technical-error.svg", "Hero image")
+
+        hero = [
+            (
+                "hero_text_wide_image",
+                {
+                    "text_content": {
+                        "hero_title": "Sample hero",
+                        "hero_subtitle": RichText("<p>Sample subtitle</p>"),
+                    },
+                    "layout": {"top_margin": 5, "bottom_margin": 5, "background_color": "blue-ecume"},
+                    "buttons": [],
+                    "image": {
+                        "image": {"image": image, "alt_text": "Photo description", "decorative": False},
+                        "image_ratio": "fr-ratio-16x9",
+                        "image_width": "fr-content-media--sm",
+                        "image_positioning": "",
+                    },
+                },
+            )
+        ]
+        self.content_page = home.add_child(
+            instance=ContentPage(
+                title="Translation hero image page",
+                slug="translation-hero-image",
+                hero=hero,
+                body=[],
+            )
+        )
+        self.content_page.save()
+
+    def test_extract_segments_with_deeply_nested_image_does_not_crash(self):
+        # Without the monkey patch this raises AttributeError:
+        # 'NoneType' object has no attribute 'get'
+        segments = extract_segments(self.content_page)
+        self.assertIsInstance(segments, list)

--- a/sites_conformes/core/tests/test_translation.py
+++ b/sites_conformes/core/tests/test_translation.py
@@ -62,3 +62,48 @@ class TranslationImageBlockExtractionTestCase(WagtailPageTestCase):
         # 'NoneType' object has no attribute 'get'
         segments = extract_segments(self.content_page)
         self.assertIsInstance(segments, list)
+
+
+class TranslationSimpleImageBlockExtractionTestCase(WagtailPageTestCase):
+    """
+    Make sure the monkey patch does not break extraction for a hero whose ImageBlock is only one
+    level deep which never triggered the bug. Here raw_value is a proper dict, so segments must still
+    be extracted normally.
+    """
+
+    def setUp(self):
+        home = Page.objects.get(slug="home")
+        image = import_image("sites_conformes/static/artwork/technical-error.svg", "Hero image")
+
+        hero = [
+            (
+                "hero_text_image",
+                {
+                    "text_content": {
+                        "hero_title": "Sample hero",
+                        "hero_subtitle": RichText("<p>Sample subtitle</p>"),
+                    },
+                    "buttons": [],
+                    "image": {"image": image, "alt_text": "Photo description", "decorative": False},
+                    "layout": {"top_margin": 5, "bottom_margin": 5, "background_color": "blue-ecume"},
+                },
+            )
+        ]
+        self.content_page = home.add_child(
+            instance=ContentPage(
+                title="Translation simple hero image page",
+                slug="translation-simple-hero-image",
+                hero=hero,
+                body=[],
+            )
+        )
+        self.content_page.save()
+
+    def test_extract_segments_with_single_level_image_still_works(self):
+        # The patch must not regress the working case: a one-level-deep
+        # ImageBlock must still extract its segments (e.g. the hero title).
+        segments = extract_segments(self.content_page)
+        self.assertIsInstance(segments, list)
+        self.assertTrue(segments, "expected segments to be extracted for a valid hero")
+        extracted = " ".join(str(getattr(s, "string", "")) for s in segments)
+        self.assertIn("Sample hero", extracted)


### PR DESCRIPTION
## 🎯 Objectif
Bug rencontré sur doctorat.gouv : 
> Sur la plateforme "[Doctorat.gouv.fr](http://doctorat.gouv.fr/)" je rencontre actuellement des difficultés avec la traduction des pages en anglais. Par exemple la page "A propos" en français qui devient "About us" en anglais a pu être traduite, mais il y a eu un bug au moment de la traduction en anglais des sous pages. Elles n'apparaissent pas sous "About us" dansle menu des pages de la version en anglais. De plus quand on les trouve grâce au champ de recherche, il y a une erreur serveur 500 pour les modifier ou les supprimer. Donc c'est bloqué. Je ne peux même pas les supprimer et recommencer.

La soumission d'une page à la traduction  renvoie une 500 lorsque la page contient un ImageBlock imbriqué à au moins deux niveaux de StructBlock (ex. les heros « image large » et « image de fond »).

wagtail-localize, dans `StreamFieldSegmentExtractor.handle_struct_block`, ne propage le `raw_value` que d'un seul niveau 

## 🔍 Implémentation

un monkeypatch de handle_image_block appliqué dans apps.ready(), gardant le cas `raw_value=None`. + test de non-régression (rouge sans le patch, vert avec).


## ⚠️ Informations supplémentaires

Bug reproduit sur la staging, PR poussé sur la staging et traduction relancée qui fonctionne 

<img width="1052" height="206" alt="Capture d’écran 2026-06-22 à 15 28 00" src="https://github.com/user-attachments/assets/20e45006-68df-4223-ab1a-79018a5addb8" />
<img width="1512" height="322" alt="Capture d’écran 2026-06-22 à 15 27 51" src="https://github.com/user-attachments/assets/31ff690d-1fee-43bb-b133-31bbfe5fa3af" />

Une PR a été créé upstream : https://github.com/wagtail/wagtail-localize/pull/935


## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
