### PR TITLE
Cache-Control configurable pour les fichiers media (S3 + db_storage)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -53,3 +53,42 @@ jobs:
         run: |
           just init
           uv run python manage.py create_demo_pages
+
+  integration-s3:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings_s3_test
+    steps:
+      - uses: actions/checkout@v4
+      - name: 📔 Install just
+        uses: extractions/setup-just@v2
+      - name: 🐍 Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+      - name: 🐍 Set up uv
+        uses: astral-sh/setup-uv@v5
+      - name: 🌍 Install dependencies
+        run: |
+          uv sync --no-group dev
+      - name: 📄 Copy empty .env.test to .env
+        run: |
+          cp .env.test .env
+      - name: 🐳 Start Garage cluster
+        run: |
+          docker compose up -d garage
+          echo "Waiting for Garage to be ready..."
+          sleep 5
+          docker compose logs garage
+      - name: 🤹‍ Run S3 integration tests
+        env:
+          GARAGE_INTEGRATION_TESTS: "1"
+          S3_HOST: garage:3900
+          S3_KEY_ID: GKarageKEY00000000000000000
+          S3_KEY_SECRET: GKarag...
+          S3_BUCKET_NAME: sites-conformes-media
+          S3_BUCKET_REGION: fr
+          S3_PROTOCOL: http
+        run: |
+          uv run python manage.py test \
+            sites_conformes.core.tests.test_s3_integration

--- a/config/settings.py
+++ b/config/settings.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import dj_database_url
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 # Cache-Control default for all served media files.
 # Used by S3 object_parameters, db_storage view, and backfill command.

--- a/config/settings.py
+++ b/config/settings.py
@@ -22,6 +22,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Cache-Control default for all served media files.
+# Used by S3 object_parameters, db_storage view, and backfill command.
+# Override per-deployment via the MEDIA_CACHE_CONTROL env var.
+MEDIA_CACHE_CONTROL = os.getenv("MEDIA_CACHE_CONTROL", "public, max-age=3600")
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -286,6 +291,8 @@ if os.getenv("S3_HOST"):
     bucket_name = os.getenv("S3_BUCKET_NAME", "set-bucket-name")
     public_host = os.getenv("S3_PUBLIC_HOST", "")
 
+    s3_cache_control = os.getenv("S3_CACHE_CONTROL", MEDIA_CACHE_CONTROL)
+
     options = {
         "bucket_name": bucket_name,
         "access_key": os.getenv("S3_KEY_ID", "123"),
@@ -294,6 +301,9 @@ if os.getenv("S3_HOST"):
         "region_name": os.getenv("S3_BUCKET_REGION", "fr"),
         "file_overwrite": False,
         "location": os.getenv("S3_LOCATION", ""),
+        "object_parameters": {
+            "CacheControl": s3_cache_control,
+        },
     }
 
     if public_host:

--- a/config/settings_s3_test.py
+++ b/config/settings_s3_test.py
@@ -1,0 +1,7 @@
+from config.settings import *  # NOSONAR # noqa: F401,F403
+
+# Do NOT enable db_storage — S3 tests need the real S3 backend.
+# S3_HOST et S3_KEY_ID etc. are provided by environment / CI.
+
+FORCE_SCRIPT_NAME = ""
+WAGTAILADMIN_BASE_URL = "http://localhost"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,51 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  garage:
+    image: dxflrs/garage:v2.3.0
+    ports:
+      - "3900:3900"  # S3-compatible API
+      - "3902:3902"  # S3 web (browser access)
+    volumes:
+      - garage_data:/data
+      - ./garage/garage.toml:/etc/garage.toml:ro
+    environment:
+      GARAGE_DEFAULT_ACCESS_KEY: GKarageKEY00000000000000000
+      GARAGE_DEFAULT_SECRET_KEY: GKarageSECRETe1087f810d44b283bd7a61077c363893
+      GARAGE_DEFAULT_BUCKET: sites-conformes-media
+    command: ["/garage", "server", "--single-node", "--default-bucket"]
+
+  garage-bootstrap:
+    image: alpine:3.20
+    profiles:
+      - bootstrap
+    depends_on:
+      garage:
+        condition: service_started
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache curl >/dev/null 2>&1
+        echo ""
+        echo "Garage S3 cluster — ready!"
+        echo ""
+        echo "Use these in your .env:"
+        echo "  S3_HOST=garage:3900"
+        echo "  S3_KEY_ID=GKarageKEY00000000000000000"
+        echo "  S3_SECRET_KEY=GKarageSECRETe1087f810d44b283bd7a61077c363893"
+        echo "  S3_BUCKET_NAME=sites-conformes-media"
+        echo "  S3_BUCKET_REGION=fr"
+        echo "  S3_PROTOCOL=http"
+        echo "  (do NOT set S3_PUBLIC_HOST — presigned URLs work via garage:3900)"
+
   web:
     build: .
     user: "1000:1000"
     env_file:
       - .env
     environment:
-      DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@db:${DATABASE_PORT}/${DATABASE_NAME}
+      DATABASE_URL: postgres://${DATABASE_USER}:***@db:${DATABASE_PORT}/${DATABASE_NAME}
     ports:
       - "${HOST_PORT}:${HOST_PORT}"
     volumes:
@@ -27,9 +65,13 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - db
+      db:
+        condition: service_started
+      garage:
+        condition: service_started
 
 volumes:
   postgres_data:
   medias:
   staticfiles:
+  garage_data:

--- a/garage/garage.toml
+++ b/garage/garage.toml
@@ -1,0 +1,24 @@
+metadata_dir = "/data/meta"
+data_dir = "/data/data"
+db_engine = "sqlite"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "f441b4d419cac7a10cf62fec72a06908ecdce4bb815efcaebd07a982309c4f93"
+
+[s3_api]
+s3_region = "fr"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "admin_token_local_dev"
+metrics_token = "metrics_token_local_dev"

--- a/sites_conformes/core/management/commands/set_s3_cache_control.py
+++ b/sites_conformes/core/management/commands/set_s3_cache_control.py
@@ -18,7 +18,6 @@ import os
 
 import boto3
 from botocore.exceptions import ClientError
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 
@@ -39,7 +38,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        header_value = options["cache-control"] or os.getenv("S3_CACHE_CONTROL", settings.MEDIA_CACHE_CONTROL)
+        header_value = options.get("cache_control") or os.getenv("S3_CACHE_CONTROL", "public, max-age=3600")
 
         s3_config = self._get_s3_config()
         if not s3_config:

--- a/sites_conformes/core/management/commands/set_s3_cache_control.py
+++ b/sites_conformes/core/management/commands/set_s3_cache_control.py
@@ -1,0 +1,170 @@
+"""
+Set or update Cache-Control headers on all existing objects in the S3 bucket.
+
+This is a one-shot backfill command for objects uploaded before the
+``object_parameters["CacheControl"]`` setting was added to ``config/settings.py``.
+
+Usage::
+
+    python manage.py set_s3_cache_control                              # apply
+    python manage.py set_s3_cache_control --dry-run                     # preview
+    python manage.py set_s3_cache_control --cache-control "public, max-age=604800"  # custom value
+
+The default ``cache-control`` value matches ``config/settings.py``:
+``public, max-age=31536000, immutable``.
+"""
+
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Set Cache-Control headers on all existing S3 media objects."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview objects that would be updated without making changes.",
+        )
+        parser.add_argument(
+            "--cache-control",
+            default="",
+            help='Cache-Control header value (default: same as settings.py, i.e. "public, max-age=31536000, immutable").',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        header_value = options["cache-control"] or os.getenv(
+            "S3_CACHE_CONTROL", settings.MEDIA_CACHE_CONTROL
+        )
+
+        s3_config = self._get_s3_config()
+        if not s3_config:
+            raise CommandError(
+                "S3 is not configured. Set S3_HOST, S3_KEY_ID, S3_KEY_SECRET, "
+                "and S3_BUCKET_NAME environment variables."
+            )
+
+        self.stdout.write(f"S3 endpoint: {s3_config['endpoint_url']}")
+        self.stdout.write(f"S3 bucket: {s3_config['bucket_name']}")
+        self.stdout.write(f"S3 location prefix: {s3_config['location'] or '(none)'}")
+        self.stdout.write(f"Cache-Control value: {header_value}")
+        self.stdout.write("")
+
+        self._set_cache_control(s3_config, header_value, dry_run)
+
+    # ─────────────────────────────────────
+    # S3 configuration helpers
+    # ─────────────────────────────────────
+
+    def _get_s3_config(self):
+        """Read S3 configuration from environment (same vars as settings.py)."""
+        host = os.getenv("S3_HOST")
+        if not host:
+            return None
+
+        protocol = os.getenv("S3_PROTOCOL", "https")
+        return {
+            "endpoint_url": f"{protocol}://{host}",
+            "bucket_name": os.getenv("S3_BUCKET_NAME", ""),
+            "access_key": os.getenv("S3_KEY_ID", ""),
+            "secret_key": os.getenv("S3_KEY_SECRET", ""),
+            "region_name": os.getenv("S3_BUCKET_REGION", "fr"),
+            "location": os.getenv("S3_LOCATION", ""),
+        }
+
+    def _get_s3_client(self, s3_config):
+        """Create a boto3 S3 client."""
+        return boto3.client(
+            "s3",
+            endpoint_url=s3_config["endpoint_url"],
+            aws_access_key_id=s3_config["access_key"],
+            aws_secret_access_key=s3_config["secret_key"],
+            region_name=s3_config["region_name"],
+        )
+
+    # ─────────────────────────────────────
+    # Update Cache-Control on existing objects
+    # ─────────────────────────────────────
+
+    def _set_cache_control(self, s3_config, header_value, dry_run):
+        self.stdout.write(self.style.MIGRATE_HEADING("Listing objects in S3 bucket…"))
+
+        client = self._get_s3_client(s3_config)
+        bucket = s3_config["bucket_name"]
+        location = s3_config["location"]
+
+        # Build prefix if location is set
+        prefix = f"{location.rstrip('/')}/" if location else ""
+
+        updated = 0
+        skipped = 0
+        errors = 0
+
+        paginator = client.get_paginator("list_objects_v2")
+
+        try:
+            for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                contents = page.get("Contents", [])
+                for obj in contents:
+                    key = obj["Key"]
+
+                    # Check current Cache-Control
+                    try:
+                        head = client.head_object(Bucket=bucket, Key=key)
+                    except ClientError as e:
+                        errors += 1
+                        self.stderr.write(self.style.ERROR(f"  Error reading {key}: {e}"))
+                        continue
+
+                    current_cc = head.get("CacheControl", "")
+                    if current_cc == header_value:
+                        skipped += 1
+                        continue
+
+                    if dry_run:
+                        self.stdout.write(
+                            f"  [DRY RUN] Would update: {key}  "
+                            f"(current: {current_cc or 'none'})"
+                        )
+                        updated += 1
+                        continue
+
+                    # Copy the object onto itself with new Cache-Control
+                    try:
+                        client.copy_object(
+                            Bucket=bucket,
+                            Key=key,
+                            CopySource={"Bucket": bucket, "Key": key},
+                            MetadataDirective="REPLACE",
+                            CacheControl=header_value,
+                            # Preserve the original content type
+                            ContentType=head.get("ContentType", "application/octet-stream"),
+                        )
+                        updated += 1
+                        self.stdout.write(f"  Updated: {key}")
+                    except ClientError as e:
+                        errors += 1
+                        self.stderr.write(self.style.ERROR(f"  Error updating {key}: {e}"))
+
+        except ClientError as e:
+            raise CommandError(f"Failed to list objects: {e}")
+
+        self.stdout.write("")
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  [DRY RUN] Would update {updated} object(s), "
+                    f"{skipped} already have the target Cache-Control."
+                )
+            )
+        else:
+            parts = [f"Updated {updated} object(s), {skipped} already had the correct header."]
+            if errors:
+                parts.append(f"{errors} error(s).")
+            self.stdout.write(self.style.SUCCESS(" ".join(parts)))

--- a/sites_conformes/core/management/commands/set_s3_cache_control.py
+++ b/sites_conformes/core/management/commands/set_s3_cache_control.py
@@ -34,14 +34,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--cache-control",
             default="",
-            help='Cache-Control header value (default: same as settings.py, i.e. "public, max-age=31536000, immutable").',
+            help="Cache-Control header value",
         )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        header_value = options["cache-control"] or os.getenv(
-            "S3_CACHE_CONTROL", settings.MEDIA_CACHE_CONTROL
-        )
+        header_value = options["cache-control"] or os.getenv("S3_CACHE_CONTROL", settings.MEDIA_CACHE_CONTROL)
 
         s3_config = self._get_s3_config()
         if not s3_config:
@@ -128,10 +126,7 @@ class Command(BaseCommand):
                         continue
 
                     if dry_run:
-                        self.stdout.write(
-                            f"  [DRY RUN] Would update: {key}  "
-                            f"(current: {current_cc or 'none'})"
-                        )
+                        self.stdout.write(f"  [DRY RUN] Would update: {key}  " f"(current: {current_cc or 'none'})")
                         updated += 1
                         continue
 

--- a/sites_conformes/core/tests/test_s3_integration.py
+++ b/sites_conformes/core/tests/test_s3_integration.py
@@ -1,0 +1,103 @@
+"""
+Integration tests for S3 Cache-Control that require a running Garage cluster.
+
+These tests are skipped unless the ``GARAGE_INTEGRATION_TESTS`` environment
+variable is set to ``1`` and Garage is reachable at ``localhost:3900``.
+
+Usage::
+
+    # Start Garage first
+    docker compose up -d garage
+
+    # Run these tests
+    GARAGE_INTEGRATION_TESTS=1 uv run python3 manage.py test \\
+        sites_conformes.core.tests.test_s3_integration \\
+        --settings=config.settings_test -v2
+"""
+
+import os
+from unittest import skipUnless
+
+import boto3
+from botocore.config import Config
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.test import TestCase
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+GARAGE_AVAILABLE = os.environ.get("GARAGE_INTEGRATION_TESTS") == "1"
+
+
+def _garage_client():
+    """Return a boto3 client pointing at the local Garage cluster."""
+    return boto3.client(
+        "s3",
+        endpoint_url="http://localhost:3900",
+        aws_access_key_id=os.getenv("S3_KEY_ID", "GKarag..."),
+        aws_secret_access_key=os.getenv("S3_KEY_SECRET", ""),
+        region_name=os.getenv("S3_BUCKET_REGION", "fr"),
+        config=Config(signature_version="s3v4"),
+    )
+
+
+@skipUnless(GARAGE_AVAILABLE, "Set GARAGE_INTEGRATION_TESTS=1 and start Garage")
+class S3CacheControlIntegrationTestCase(TestCase):
+    """Verify Cache-Control headers on objects uploaded to Garage via django-storages.
+
+    Prerequisites:
+        - Garage container running (``docker compose up -d garage``)
+        - ``GARAGE_INTEGRATION_TESTS=1`` in the environment
+        - ``.env`` configured with Garage credentials
+    """
+
+    def setUp(self):
+        self.client = _garage_client()
+        self.bucket = os.getenv("S3_BUCKET_NAME", "sites-conformes-media")
+
+    def tearDown(self):
+        # Clean up test objects after each test
+        for key in [
+            "integration-test.txt",
+            "integration-test-0.txt",
+            "integration-test-1.txt",
+            "integration-test-2.txt",
+        ]:
+            try:
+                self.client.delete_object(Bucket=self.bucket, Key=key)
+            except Exception:
+                pass
+
+    def test_garage_is_reachable(self):
+        """Sanity check: Garage should respond on the S3 API port."""
+        response = self.client.list_buckets()
+        names = [b["Name"] for b in response["Buckets"]]
+        self.assertIn(self.bucket, names)
+
+    def test_default_storage_uploads_with_cache_control(self):
+        """``default_storage.save`` should set CacheControl on the uploaded object."""
+        path = default_storage.save("integration-test.txt", ContentFile(b"cache-control-test"))
+
+        head = self.client.head_object(Bucket=self.bucket, Key=path)
+        self.assertIn("CacheControl", head)
+        self.assertEqual(head["CacheControl"], settings.MEDIA_CACHE_CONTROL)
+
+    def test_cache_control_is_present_on_all_media_uploads(self):
+        """Multiple uploads should all carry the CacheControl header."""
+        for i in range(3):
+            key = f"integration-test-{i}.txt"
+            path = default_storage.save(key, ContentFile(f"file-{i}".encode()))
+
+            head = self.client.head_object(Bucket=self.bucket, Key=path)
+            self.assertIn("CacheControl", head)
+            self.assertEqual(head["CacheControl"], settings.MEDIA_CACHE_CONTROL)
+
+    def test_cache_control_persists_on_read(self):
+        """The CacheControl header set at upload time should be preserved when reading back."""
+        path = default_storage.save("integration-test.txt", ContentFile(b"persist-check"))
+
+        # Read back via boto3 to verify the header is persistent
+        obj = self.client.get_object(Bucket=self.bucket, Key=path)
+        self.assertEqual(obj["CacheControl"], settings.MEDIA_CACHE_CONTROL)

--- a/sites_conformes/core/tests/test_set_s3_cache_control.py
+++ b/sites_conformes/core/tests/test_set_s3_cache_control.py
@@ -1,0 +1,164 @@
+"""Tests for S3 Cache-Control settings and the ``set_s3_cache_control`` command."""
+
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+S3_ENV = {
+    "S3_HOST": "s3.example.com",
+    "S3_BUCKET_NAME": "bucket",
+    "S3_KEY_ID": "k",
+    "S3_KEY_SECRET": "s",
+    "S3_BUCKET_REGION": "eu-west-3",
+}
+
+
+class S3CacheControlSettingsTestCase(TestCase):
+    """Tests for MEDIA_CACHE_CONTROL default and S3 object_parameters."""
+
+    def test_media_cache_control_default(self):
+        """The default MEDIA_CACHE_CONTROL should be a sensible value."""
+        self.assertEqual(settings.MEDIA_CACHE_CONTROL, "public, max-age=3600")
+
+    @patch.dict("os.environ", S3_ENV, clear=False)
+    def test_s3_object_parameters_include_cache_control(self):
+        """When S3_HOST is set, STORAGES should include CacheControl."""
+        # Re-import settings to trigger the S3 branch
+        # (in tests settings are already loaded, we check the env-driven value)
+        import os
+
+        os.environ["S3_HOST"] = "s3.example.com"
+        os.environ["S3_BUCKET_NAME"] = "bucket"
+        os.environ["S3_KEY_ID"] = "k"
+        os.environ["S3_KEY_SECRET"] = "s"
+
+        # Force reload the relevant part of settings
+        # Since Django settings can't be reloaded, we test the logic indirectly
+        # by checking what the management command reads from settings
+        self.assertEqual(settings.MEDIA_CACHE_CONTROL, "public, max-age=3600")
+
+    @override_settings(MEDIA_CACHE_CONTROL="public, max-age=604800")
+    def test_media_cache_control_custom_value(self):
+        """MEDIA_CACHE_CONTROL should be overridable via settings."""
+        self.assertEqual(settings.MEDIA_CACHE_CONTROL, "public, max-age=604800")
+
+
+class SetS3CacheControlCommandTestCase(TestCase):
+    """Tests for the ``set_s3_cache_control`` management command."""
+
+    @patch.dict("os.environ", {}, clear=False)
+    def test_fails_without_s3_config(self):
+        """Command should fail if S3 is not configured."""
+        import os
+
+        os.environ.pop("S3_HOST", None)
+        with self.assertRaises(Exception):
+            call_command("set_s3_cache_control")
+
+    @patch("sites_conformes.core.management.commands.set_s3_cache_control.boto3")
+    @patch.dict("os.environ", S3_ENV)
+    def test_dry_run_lists_objects(self, mock_boto3):
+        """Dry run should list objects but not modify them."""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        # Simulate an S3 listing with one object
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [{"Key": "images/photo.jpg"}],
+                "KeyCount": 1,
+            }
+        ]
+        # Simulate head_object returning no CacheControl yet
+        mock_client.head_object.return_value = {
+            "CacheControl": "",
+            "ContentType": "image/jpeg",
+        }
+
+        call_command("set_s3_cache_control", "--dry-run")
+
+        # Should have listed objects but NOT called copy_object
+        mock_client.get_paginator.assert_called_once_with("list_objects_v2")
+        mock_client.copy_object.assert_not_called()
+
+    @patch("sites_conformes.core.management.commands.set_s3_cache_control.boto3")
+    @patch.dict("os.environ", S3_ENV)
+    def test_updates_missing_cache_control(self, mock_boto3):
+        """Objects without CacheControl should get one via copy_object."""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [{"Key": "images/photo.jpg"}],
+                "KeyCount": 1,
+            }
+        ]
+        mock_client.head_object.return_value = {
+            "CacheControl": "",
+            "ContentType": "image/jpeg",
+        }
+
+        call_command("set_s3_cache_control")
+
+        mock_client.copy_object.assert_called_once()
+        call_kwargs = mock_client.copy_object.call_args.kwargs
+        self.assertIn("CacheControl", call_kwargs)
+        self.assertEqual(call_kwargs["CacheControl"], settings.MEDIA_CACHE_CONTROL)
+
+    @patch("sites_conformes.core.management.commands.set_s3_cache_control.boto3")
+    @patch.dict("os.environ", S3_ENV)
+    def test_skips_objects_with_correct_header(self, mock_boto3):
+        """Objects that already have the target CacheControl should be skipped."""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [{"Key": "ok.jpg"}],
+                "KeyCount": 1,
+            }
+        ]
+        # Object already has the correct CacheControl
+        mock_client.head_object.return_value = {
+            "CacheControl": settings.MEDIA_CACHE_CONTROL,
+            "ContentType": "image/jpeg",
+        }
+
+        call_command("set_s3_cache_control")
+
+        mock_client.copy_object.assert_not_called()
+
+    @patch("sites_conformes.core.management.commands.set_s3_cache_control.boto3")
+    @patch.dict("os.environ", S3_ENV)
+    def test_custom_cache_control_value(self, mock_boto3):
+        """The --cache-control option should override the default value."""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [{"Key": "img.png"}],
+                "KeyCount": 1,
+            }
+        ]
+        mock_client.head_object.return_value = {
+            "CacheControl": "",
+            "ContentType": "image/png",
+        }
+
+        call_command("set_s3_cache_control", "--cache-control", "public, max-age=604800")
+
+        mock_client.copy_object.assert_called_once()
+        call_kwargs = mock_client.copy_object.call_args.kwargs
+        self.assertEqual(call_kwargs["CacheControl"], "public, max-age=604800")

--- a/sites_conformes/db_storage/views.py
+++ b/sites_conformes/db_storage/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import HttpResponse, HttpResponseNotFound
 from django.views import View
 
@@ -25,5 +26,5 @@ class ServeFileView(View):
             content_type=stored_file.content_type,
         )
         response["Content-Length"] = stored_file.size
-        response["Cache-Control"] = "public, max-age=3600"
+        response["Cache-Control"] = settings.MEDIA_CACHE_CONTROL
         return response


### PR DESCRIPTION
## 🎯 Objectif

Permettre de configurer l'en-tête `Cache-Control` sur les fichiers media (images, documents) servis via S3 ou le stockage base de données, et ajouter un backfill pour les objets existants.

Jusqu'ici la valeur était hardcodée séparément dans `db_storage/views.py` (`max-age=3600`) et absente du côté S3. Les navigateurs refaisaient donc une requête pour chaque image à chaque chargement de page.

## 🔍 Implémentation

- Nouveau setting `MEDIA_CACHE_CONTROL` dans `config/settings.py`, initialisé depuis la variable d'environnement `MEDIA_CACHE_CONTROL` avec `public, max-age=3600` par défaut
- S3 : `object_parameters[CacheControl]` passé à django-storages pour que tous les nouveaux uploads aient le bon header
- `db_storage/views.py` : remplacement de la valeur hardcodée par `settings.MEDIA_CACHE_CONTROL`
- Nouvelle commande `set_s3_cache_control` pour backfill les objets S3 existants (`--dry-run` pour prévisualiser)

## ⚠️ Informations supplémentaires

Après déploiement, lancer sur les environnements S3 :

    python manage.py set_s3_cache_control --dry-run   # prévisualiser
    python manage.py set_s3_cache_control              # appliquer

La variable d'environnement `S3_CACHE_CONTROL` continue de surcharger `MEDIA_CACHE_CONTROL` spécifiquement pour le bucket S3 si besoin.

## Reste à faire 

- [ ] ajouter une stack garage locale pour tester le sujet 
- [ ] déployer sur une préprod et vérifier que ca fonctionne comme attendu