### PR TITLE
Correctif : afficher la date des évènements sur le bloc "Articles récents de l'agenda"

### DIFF
--- a/sites_conformes/core/templates/sites_conformes_core/blocks/events_recent_entries.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/events_recent_entries.html
@@ -80,7 +80,9 @@
               <h2 class="fr-card__title">
                 <a href="{{ post.url }}">{{ post.title|truncatewords:8 }}</a>
               </h2>
-              <p class="fr-card__desc">Publié le {{ post.date |date:'l j F Y' }}</p>
+               <p class="fr-card__desc fr-icon-calendar-event-fill">
+                {% event_date_range post.event_date_start post.event_date_end %}
+              </p>
               {% if post.event_categories.all %}
                 <div class="fr-card__start">
                   <ul class="fr-tags-group">

--- a/sites_conformes/core/templatetags/wagtail_dsfr_tags.py
+++ b/sites_conformes/core/templatetags/wagtail_dsfr_tags.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from django import template
 from django.conf import settings
 from django.template.context import Context
+from django.utils.formats import date_format
 from django.utils.html import mark_safe
 from wagtail.models import Site
 from wagtail.rich_text import RichText
@@ -177,6 +178,26 @@ def toggle_url_filter(context, *_, **kwargs):
         return f"?{url_string}"
     else:
         return ""
+
+
+@register.simple_tag
+def event_date_range(event_date_start, event_date_end):
+    """
+    Formatting the date range of an event by factoring out common parts (same day, same month, or same year).
+    """
+    if not event_date_start or not event_date_end:
+        return ""
+
+    start = event_date_start.date() if hasattr(event_date_start, "date") else event_date_start
+    end = event_date_end.date() if hasattr(event_date_end, "date") else event_date_end
+
+    if start == end:
+        return date_format(start)
+    if start.year == end.year and start.month == end.month:
+        return f"{start.day} – {date_format(end)}"
+    if start.year == end.year:
+        return f"{date_format(start, 'j F')} – {date_format(end, 'j F Y')}"
+    return f"{date_format(start)} – {date_format(end)}"
 
 
 @register.filter

--- a/sites_conformes/core/tests/test_wagtail_dsfr_tags.py
+++ b/sites_conformes/core/tests/test_wagtail_dsfr_tags.py
@@ -1,5 +1,7 @@
+from datetime import date, datetime
+
 from django.template import Context
-from django.test import RequestFactory
+from django.test import RequestFactory, SimpleTestCase
 from django.utils.translation import override
 from wagtail.models import Locale, Page, Site
 from wagtail.test.utils import WagtailPageTestCase
@@ -160,3 +162,46 @@ class LanguageSelectorTagManualTestCase(LanguageSelectorTagBaseTestCase):
             "</a>",
             html,
         )
+
+
+class EventDateRangeTagTestCase(SimpleTestCase):
+    def test_same_day(self):
+        from sites_conformes.core.templatetags.wagtail_dsfr_tags import event_date_range
+
+        with override("fr"):
+            result = event_date_range(date(2026, 1, 5), date(2026, 1, 5))
+        self.assertEqual(result, "5 janvier 2026")
+
+    def test_same_month_and_year(self):
+        from sites_conformes.core.templatetags.wagtail_dsfr_tags import event_date_range
+
+        with override("fr"):
+            result = event_date_range(date(2026, 1, 5), date(2026, 1, 8))
+        self.assertEqual(result, "5 – 8 janvier 2026")
+
+    def test_same_year_different_month(self):
+        from sites_conformes.core.templatetags.wagtail_dsfr_tags import event_date_range
+
+        with override("fr"):
+            result = event_date_range(date(2026, 1, 5), date(2026, 3, 8))
+        self.assertEqual(result, "5 janvier – 8 mars 2026")
+
+    def test_different_year(self):
+        from sites_conformes.core.templatetags.wagtail_dsfr_tags import event_date_range
+
+        with override("fr"):
+            result = event_date_range(date(2026, 1, 5), date(2027, 1, 8))
+        self.assertEqual(result, "5 janvier 2026 – 8 janvier 2027")
+
+    def test_accepts_datetimes(self):
+        from sites_conformes.core.templatetags.wagtail_dsfr_tags import event_date_range
+
+        with override("fr"):
+            result = event_date_range(datetime(2026, 1, 5, 9, 0), datetime(2026, 1, 5, 18, 0))
+        self.assertEqual(result, "5 janvier 2026")
+
+    def test_returns_empty_when_missing_date(self):
+        from sites_conformes.core.templatetags.wagtail_dsfr_tags import event_date_range
+
+        self.assertEqual(event_date_range(None, date(2026, 1, 5)), "")
+        self.assertEqual(event_date_range(date(2026, 1, 5), None), "")

--- a/sites_conformes/events/templates/sites_conformes_events/blocks/events_index_posts_list.html
+++ b/sites_conformes/events/templates/sites_conformes_events/blocks/events_index_posts_list.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtail_dsfr_tags %}
 {% for post in posts %}
   <div class="fr-col fr-col-md-6">
     <div class="fr-card fr-enlarge-link">
@@ -8,15 +8,7 @@
             <a href="{{ post.url }}">{{ post.title }}</a>
           </h3>
           <p class="fr-card__desc fr-icon-calendar-event-fill">
-            {% if post.event_date_start.date == post.event_date_end.date %}
-              {{ post.event_date_start.date }}
-            {% elif post.event_date_start.year == post.event_date_end.year and post.event_date_start.month == post.event_date_end.month %}
-              {{ post.event_date_start.day }} – {{ post.event_date_end.date }}
-            {% elif post.event_date_start.year == post.event_date_end.year %}
-              {{ post.event_date_start|date:"j F" }} – {{ post.event_date_end|date:"j F Y" }}
-            {% else %}
-              {{ post.event_date_start.date }} – {{ post.event_date_end.date }}
-            {% endif %}
+            {% event_date_range post.event_date_start post.event_date_end %}
           </p>
           {% if post.event_categories.all %}
             <div class="fr-card__start">

--- a/sites_conformes/events/templates/sites_conformes_events/event_entry_page.html
+++ b/sites_conformes/events/templates/sites_conformes_events/event_entry_page.html
@@ -52,15 +52,7 @@
       <p>
         <strong>
           <span class="fr-icon-calendar-event-fill click-to-copy" aria-hidden="true"></span>
-          {% if page.event_date_start.date == page.event_date_end.date %}
-            {{ page.event_date_start.date }}
-          {% elif page.event_date_start.year == page.event_date_end.year and page.event_date_start.month == page.event_date_end.month %}
-            {{ page.event_date_start.day }} – {{ page.event_date_end.date }}
-          {% elif page.event_date_start.year == page.event_date_end.year %}
-            {{ page.event_date_start|date:"j F" }} – {{ page.event_date_end|date:"j F Y" }}
-          {% else %}
-            {{ page.event_date_start.date }} – {{ page.event_date_end.date }}
-          {% endif %}
+          {% event_date_range page.event_date_start page.event_date_end %}
         </strong>
         {% if categories %}
           |
@@ -104,7 +96,7 @@
           <h2 class="fr-card__title">{{ page.title }}</h2>
           <ul class="fr-card__desc">
             <li>
-              <strong>{% translate "Date:" %}</strong> {{ page.event_date_start }} - {{ page.event_date_end }}
+              <strong>{% translate "Date:" %}</strong>{{ page.event_date_start }} - {{ page.event_date_end }}
             </li>
             <li>
               <strong>{% translate "Location:" %}</strong> {{ page.location }}


### PR DESCRIPTION
## 🎯 Objectif

Le bloc "Articles récents de l'agenda" présentent les blocs avec les dates de publication au lieu des dates des évènements. 

Bugfix + refacto

## 🔍 Implémentation

- Ajout d'un template tag pour gérer la logique de rendu de la date 
- Ajout de tests sur le template tag
- Modification sur le bloc en question pour afficher la date des évènements plutôt que la date de publication des pages. 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images
AVANT
<img width="1054" height="392" alt="Capture d’écran 2026-07-01 à 16 02 56" src="https://github.com/user-attachments/assets/31a29a82-6b13-4f70-8c5f-a534b564438a" />

APRES
<img width="1174" height="415" alt="Capture d’écran 2026-07-01 à 16 03 47" src="https://github.com/user-attachments/assets/b60cf611-8b48-4ebe-90a2-639d5e6de067" />

