### PR TITLE
Corrige les commandes i18n (makemessages/compilemessages)

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ collectstatic:
 # Compile the translation files
 [group('Internationalization')]
 compilemessages:
-    {{docker_cmd}} {{uv_run}} django-admin compilemessages -l fr --ignore=.venv
+    {{docker_cmd}} {{uv_run}} python manage.py compilemessages -l fr --ignore=.venv
 
 alias csu := createsuperuser
 createsuperuser:
@@ -60,8 +60,8 @@ alias messages := makemessages
 # Update the translation files
 [group('Internationalization')]
 makemessages:
-    {{docker_cmd}} {{uv_run}} django-admin makemessages -l fr --ignore=manage.py --ignore=config --ignore=medias --ignore=__init__.py --ignore=setup.py --ignore=staticfiles  --no-location
-    {{docker_cmd}} {{uv_run}} django-admin makemessages -d djangojs -l fr --ignore=config --ignore=medias --ignore=staticfiles --no-location
+    {{docker_cmd}} {{uv_run}} python manage.py makemessages -l fr --ignore=manage.py --ignore=config --ignore=medias --ignore=__init__.py --ignore=setup.py --ignore=staticfiles  --no-location
+    {{docker_cmd}} {{uv_run}} python manage.py makemessages -d djangojs -l fr --ignore=config --ignore=medias --ignore=staticfiles --no-location
 
 alias mm:= makemigrations
 makemigrations app="":


### PR DESCRIPTION
## 🎯 Objectif

`just makemessages` a été cassé en local par la migration de la packagification. Fix : Utiliser `manage.py makemessages` au lieu de `django-admin makemessages`. 

django-admin ne trouve plus le dossier `locale/` depuis qu'il n'est plus dans le root. Il faut lui spécifier de loader DJANGO_SETTINGS_MODULE (comme on fait dans ci-check-i18n.yml) pour qu'il le trouve.
Alors que manage.py fait le loading tout seul. Donc je propose de passer à manage.py.

J'ai aussi passé compilemessages à manage.py, plutot pour que toutes les commandes utilisent la meme chose (en soit c'est pas indispensable, il n'etait pas cassé)


