### PR TITLE
Add hooks for customizing search results

### DIFF
--- a/sites_conformes/core/search_registry.py
+++ b/sites_conformes/core/search_registry.py
@@ -1,0 +1,65 @@
+"""Registry for fork apps to plug a custom search results view into ``/search/``.
+
+How to add a custom search app
+==============================
+
+Fork projects can replace the default search page with their own view and
+template without editing ``sites_conformes``.
+
+1. Create a Django app outside ``sites_conformes/``
+   (see https://github.com/betagouv/agreste/tree/main-agreste/faceted_search
+   for a full example).
+
+2. Subclass :class:`~sites_conformes.core.views.SearchResultsView` and override
+   the extension points as needed:
+
+   - ``filter_before_search(queryset, site)`` — narrow candidates before
+     ``.search()`` (e.g. facet filters)
+   - ``filter_after_search(queryset, site)`` — refine results after
+     ``.search()`` (e.g. custom ranking, deduplication)
+   - ``get_search_filter_context(site)`` — extra template context (e.g. a
+     filter sidebar)
+   - ``template_name`` — your app's search results template
+
+3. Register the view when the app starts::
+
+       # my_search/apps.py
+       def ready(self):
+           from my_search.views import MySearchResultsView
+           from sites_conformes.core.search_registry import register_search_view
+
+           register_search_view(MySearchResultsView)
+
+4. Add the app to ``INSTALLED_APPS``. The ``/search/`` URL is already wired in
+   ``sites_conformes.core.urls``; no URL changes are required.
+
+Only one view can be registered. If several apps call ``register_search_view``,
+the last registration wins (determined by ``INSTALLED_APPS`` order).
+
+Templates can extend ``sites_conformes_core/search_results.html`` and override
+the ``search_sidebar``, ``search_results_column_class``, ``search_results``, and
+``search_no_results`` blocks.
+"""
+
+from sites_conformes.core.views import SearchResultsView
+
+
+class SearchRegistry:
+    def __init__(self):
+        self._view_class = None
+
+    def register(self, view_class):
+        self._view_class = view_class
+
+    def clear(self):
+        self._view_class = None
+
+    def get_search_results_view(self):
+        view_class = self._view_class or SearchResultsView
+        return view_class.as_view()
+
+
+search_registry = SearchRegistry()
+
+register_search_view = search_registry.register
+get_search_results_view = search_registry.get_search_results_view

--- a/sites_conformes/core/templates/sites_conformes_core/search_results.html
+++ b/sites_conformes/core/templates/sites_conformes_core/search_results.html
@@ -21,45 +21,61 @@
 {% endif %}
 
 {% block content %}
+  {% comment %}
+  Fork projects: extend this template to add a sidebar.
+  Override search_sidebar and search_results_column_class to adjust column width with/without a sidebar (e.g. fr-col fr-col-md-8 fr-col-12).
+  {% endcomment %}
   <div class="fr-container fr-my-4w">
-    <h1>
-      {% if object_list.count %}
-        {{ object_list.count }} {% translate "result" %}{{ object_list.count|pluralize }}
-      {% else %}
-        {% translate "No results" %}
-      {% endif %}
-      {% blocktranslate %}for query "{{ query }}"{% endblocktranslate %}
-    </h1>
-    {% if object_list.count %}
-      <ol>
-        {% for result in object_list %}
-          <li>
-            <h2 class="fr-h4">
-              <a href="{% pageurl result %}">{{ result }}</a>
-            </h2>
-            {% if result.search_description %}<p>{{ result.search_description|safe }}</p>{% endif %}
+    {% block search_heading %}
+      <h1>
+        {% if object_list.count %}
+          {{ object_list.count }} {% translate "result" %}{{ object_list.count|pluralize }}
+        {% else %}
+          {% translate "No results" %}
+        {% endif %}
+        {% blocktranslate %}for query "{{ query }}"{% endblocktranslate %}
+      </h1>
+    {% endblock search_heading %}
 
-          </li>
-        {% endfor %}
-      </ol>
-    {% else %}
-      <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
-        <div class="fr-py-0 fr-col-12 fr-col-md-6">
-          <h2 class="fr-mb-3w">{% translate "We did not find any content matching your search." %}</h2>
-          <p>{% translate "To continue your visit, you can consult our home page." %}</p>
-          <div class="fr-btns-group fr-btns-group--inline-md">
-            <a class="fr-btn" href="{% root_url %}">{% translate "Back to home page" %}</a>
-          </div>
-        </div>
-        <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
-          <img src="{% static 'dsfr/dist/artwork/pictograms/digital/search.svg' %}"
-               class="fr-responsive-img"
-               alt=""
-               width="300"
-               height="300" />
-        </div>
+    <div class="fr-grid-row fr-grid-row--gutters">
+      {% block search_sidebar %}{% endblock search_sidebar %}
+
+      <div class="{% block search_results_column_class %}fr-col-12{% endblock search_results_column_class %}"
+           id="search-results">
+        {% block search_results %}
+          {% if object_list.count %}
+            <ol>
+              {% for result in object_list %}
+                <li>
+                  <h2 class="fr-h4">
+                    <a href="{% pageurl result %}">{{ result }}</a>
+                  </h2>
+                  {% if result.search_description %}<p>{{ result.search_description|safe }}</p>{% endif %}
+                </li>
+              {% endfor %}
+            </ol>
+          {% else %}
+            {% block search_no_results %}
+              <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+                <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                  <h2 class="fr-mb-3w">{% translate "We did not find any content matching your search." %}</h2>
+                  <p>{% translate "To continue your visit, you can consult our home page." %}</p>
+                  <div class="fr-btns-group fr-btns-group--inline-md">
+                    <a class="fr-btn" href="{% root_url %}">{% translate "Back to home page" %}</a>
+                  </div>
+                </div>
+                <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+                  <img src="{% static 'dsfr/dist/artwork/pictograms/digital/search.svg' %}"
+                       class="fr-responsive-img"
+                       alt=""
+                       width="300"
+                       height="300" />
+                </div>
+              </div>
+            {% endblock search_no_results %}
+          {% endif %}
+        {% endblock search_results %}
       </div>
-    {% endif %}
+    </div>
   </div>
-
 {% endblock content %}

--- a/sites_conformes/core/tests/test_search_registry.py
+++ b/sites_conformes/core/tests/test_search_registry.py
@@ -1,0 +1,28 @@
+from django.test import SimpleTestCase
+
+from sites_conformes.core.search_registry import (
+    get_search_results_view,
+    register_search_view,
+    search_registry,
+)
+from sites_conformes.core.views import SearchResultsView
+
+
+class DummySearchView(SearchResultsView):
+    marker = "dummy"
+
+
+class SearchRegistryTest(SimpleTestCase):
+    def setUp(self):
+        self._saved_view = search_registry._view_class
+
+    def tearDown(self):
+        search_registry._view_class = self._saved_view
+
+    def test_default_view_is_core_search_results_view(self):
+        search_registry.clear()
+        self.assertIs(get_search_results_view().view_class, SearchResultsView)
+
+    def test_register_replaces_default_view(self):
+        register_search_view(DummySearchView)
+        self.assertIs(get_search_results_view().view_class, DummySearchView)

--- a/sites_conformes/core/urls.py
+++ b/sites_conformes/core/urls.py
@@ -2,10 +2,11 @@ from django.urls import include, path
 from django.utils.translation import gettext_lazy as _
 from wagtail import urls as wagtail_urls
 
-from sites_conformes.core.views import SearchResultsView, SiteMapView, TagsListView, TagView
+from sites_conformes.core.search_registry import get_search_results_view
+from sites_conformes.core.views import SiteMapView, TagsListView, TagView
 
 urlpatterns = [
-    path(_("search/"), SearchResultsView.as_view(), name="cms_search"),
+    path(_("search/"), get_search_results_view(), name="cms_search"),
     path(_("sitemap/"), SiteMapView.as_view(), name="readable_sitemap"),
     path("tags/<str:tag>/", TagView.as_view(), name="global_tag"),
     path("tags/", TagsListView.as_view(), name="global_tags_list"),

--- a/sites_conformes/core/views.py
+++ b/sites_conformes/core/views.py
@@ -22,30 +22,66 @@ class SearchResultsView(ListView):
     If user is anonymous, only public pages are returned.
 
     If there is no result, an empty page list is returned.
+
+    Custom search apps:
+    ------------------
+
+    Fork projects can implement a different search by replacing this view via
+    :mod:`sites_conformes.core.search_registry` — see that module's
+    documentation for how to register a custom search app.
+    Extension points for subclasses:
+    - :meth:`filter_before_search` — narrow candidates before full-text search
+    - :meth:`filter_after_search` — refine results after full-text search
+    - :meth:`get_search_filter_context` — extra template context.
     """
 
     model = Page
     template_name = "sites_conformes_core/search_results.html"
 
+    def get_searchable_queryset(self, site):
+        root_page = site.root_page.localized
+        queryset = Page.objects.descendant_of(root_page, inclusive=True).live()
+        if not self.request.user.is_authenticated:
+            queryset = queryset.public()
+        return queryset
+
+    def filter_before_search(self, queryset, site):
+        """Return a queryset narrowed before ``.search()`` is called.
+
+        Typical uses: facet filters, scoping by page type, or any constraint
+        that should reduce the set of pages passed to the search backend
+        (e.g. ``pk__in`` filters compatible with Wagtail search).
+        """
+        return queryset
+
+    def filter_after_search(self, queryset, site):
+        """Return the queryset refined after ``.search()`` has been called.
+
+        Typical uses: custom ranking or re-ordering, relevance thresholds,
+        deduplication, promoted results, or per-group caps on the result list.
+        """
+        return queryset
+
+    def get_search_filter_context(self, site):
+        """Return extra template context (e.g. filter sidebar options)."""
+        return {}
+
     def get_queryset(self):
         site = Site.find_for_request(self.request)
-        root_page = site.root_page.localized
-
         query = self.request.GET.get("q", None)
-        if query:
-            object_list = Page.objects.descendant_of(root_page, inclusive=True).live()
+        if not query:
+            return Page.objects.none()
 
-            if not self.request.user.is_authenticated:
-                object_list = object_list.public()
-
-            object_list = object_list.search(query)
-        else:
-            object_list = Page.objects.none()
-        return object_list
+        object_list = self.get_searchable_queryset(site)
+        object_list = self.filter_before_search(object_list, site)
+        object_list = object_list.search(query)
+        return self.filter_after_search(object_list, site)
 
     def get_context_data(self, **kwargs):
         context = super(SearchResultsView, self).get_context_data(**kwargs)
         context["query"] = self.request.GET.get("q")
+        site = Site.find_for_request(self.request)
+        context.update(self.get_search_filter_context(site))
         return context
 
 

--- a/sites_conformes/forms/tests/test_forms.py
+++ b/sites_conformes/forms/tests/test_forms.py
@@ -1,8 +1,10 @@
+from django.contrib.auth.models import AnonymousUser
 from django.core.management import call_command
-from django.urls import reverse
+from django.test import RequestFactory
 from wagtail.test.utils import WagtailPageTestCase
 from wagtail_localize.models import TranslationSource
 
+from sites_conformes.core.views import SearchResultsView
 from sites_conformes.forms.models import FormField, FormPage
 
 
@@ -118,9 +120,18 @@ class FormsTestCase(WagtailPageTestCase):
     def test_form_page_is_found_in_search_results(self):
         call_command("update_index")
 
-        search_url = reverse("cms_search")
-        response = self.client.get(f"{search_url}?q=contact")
+        # Call the default search view by hand instead of using client.get(reverse("cms_search")).
+        # This is because a custom search view could be registered, and it would change the content
+        # of the search results and their page template.
+        factory = RequestFactory()
+        request = factory.get("/search/", {"q": "contact"})
+        request.user = AnonymousUser()
+        response = SearchResultsView.as_view()(request)
+        response.render()
 
         self.assertEqual(response.status_code, 200)
         self.assertInHTML("""<a href="/contact/">Contact</a>""", response.content.decode())
-        self.assertInHTML("""<h1>1 résultat pour la recherche «\xa0contact\xa0»</h1>""", response.content.decode())
+        self.assertInHTML(
+            """<h1>1 résultat pour la recherche «\xa0contact\xa0»</h1>""",
+            response.content.decode(),
+        )


### PR DESCRIPTION
## 🎯 Objectif

La page de résultats de recherche est actuellement très simple. Cette PR rajoute des blocks dans les templates et des hooks dans les views, pour que des projets fork puissent implémenter une page de résultats customisée plus complexe.

Voir la PR équivalente dans Agreste pour une implémentation d'une customisation : https://github.com/betagouv/agreste/pull/33/changes?w=1
Il s'agit d'un search à facettes : on peut filtrer par différents champs (collection, theme, auteur, tag, source) similaire à ce qu'on voit sur les page BlogIndexPage (voir screenshot plus bas)

## 🔍 Implémentation

 - Ajout de blocks dans les templates de search, qui permettent aux projets forks de remplacer ces blocks proprement, sans avoir à réécrire la template. En particulier ajouter une sidebar. (visualisez la PR avec no whitespace c'est plus clair)
  - Ajout d'un search registry : les forks doivent register leur view pour qu'elle soit utilisée en remplacement de celle de SC ([ex dans agreste](https://github.com/betagouv/agreste/pull/33/changes#diff-058ed25bd1df76c4bf4e16d19d00df6b3455c25c2f266afe3597ae0ae6a75810R13)).
  - Ajout de hooks dans sites_conformes/core/views.py : 3 fonctions que les forks peuvent overrider dans une view qui subclass celle de sites_conformes : filter_before_search, filter_after_search, get_search_filter_context

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

Le search à facettes d'Agreste : (le screenshot est en 3 parties mais c'est l'idée)

<img width="1292" height="798" alt="image" src="https://github.com/user-attachments/assets/2ae8fd5b-e8e5-4135-987a-18e222d0948b" />
<img width="1300" height="480" alt="image" src="https://github.com/user-attachments/assets/71e1baa1-b702-4043-9c5f-5371bb441499" />
<img width="1258" height="164" alt="image" src="https://github.com/user-attachments/assets/3bd8c7b2-d79a-424a-983b-153fe9e57f5e" />
