### PR TITLE
Corrige le mode de définition des versions 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@
 # The release tag IS the package version: cutting a release named e.g. v4.0.0
 # publishes sites-conformes==4.0.0 to PyPI. There is no manual version bump
 # in pyproject.toml.
+#
+# The version lives in sites_conformes/_version.py (single source of truth for
+# both the PyPI build and the runtime). On release we (1) build & publish the
+# wheel with that version, and (2) commit the bumped _version.py back to main so
+# that every source-based deployment (Scalingo, an internal server, the Docker
+# image built from the repo) picks up the right number without any extra wiring.
 name: Publish to PyPI
 
 on:
@@ -18,6 +24,45 @@ on:
         type: string
 
 jobs:
+  # Commit the resolved version into _version.py on main so that source-based
+  # deployments (Scalingo, internal servers, Docker built from the repo) run the
+  # published number instead of the committed dev fallback. This is what makes
+  # the version correct "peu importe le mode de déploiement".
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # A token allowed to push to main (branch protection may require a
+          # PAT / GitHub App token rather than the default GITHUB_TOKEN).
+          token: ${{ secrets.VERSION_BUMP_TOKEN || github.token }}
+
+      - name: Resolve version from release tag
+        if: github.event_name == 'release'
+        run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+
+      - name: Resolve version from manual input
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+
+      - name: Write and commit _version.py
+        run: |
+          printf '__version__ = "%s"\n' "${VERSION}" > sites_conformes/_version.py
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add sites_conformes/_version.py
+          if git diff --staged --quiet; then
+            echo "Version already at ${VERSION}, nothing to commit."
+          else
+            git commit -m "chore: set version to ${VERSION}"
+            git push origin main
+          fi
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/sites_conformes/__init__.py
+++ b/sites_conformes/__init__.py
@@ -1,28 +1,24 @@
-import tomllib
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
+
+from ._version import __version__ as _fallback_version
 
 default_app_config = "sites_conformes.apps.SitesConformesAppConfig"
 
 
 def _get_version() -> str:
-    """Numéro de version, avec pyproject.toml comme source unique de vérité.
+    """Numéro de version, avec `_version.py` comme source unique de vérité.
 
     On le lit de deux façons complémentaires selon le mode de déploiement :
     1. via les métadonnées du paquet quand il a été installé (ex. `pip install`) ;
-    2. sinon en lisant directement `pyproject.toml`, pour les instances qui tournent
-       depuis une simple copie du dépôt (cas courant ici) où le paquet n'est pas installé.
-    Retourne une chaîne vide si aucune des deux méthodes n'aboutit ; le reste du code gère ce cas.
+    2. sinon en retombant sur `sites_conformes._version.__version__`, pour les instances
+       qui tournent depuis une simple copie du dépôt (cas courant ici) où le paquet n'est
+       pas installé. C'est la même valeur que celle utilisée par setuptools au build
+       (cf. `[tool.setuptools.dynamic]` dans `pyproject.toml`).
     """
     try:
         return version("sites-conformes")
     except PackageNotFoundError:
-        try:
-            pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
-            with pyproject.open("rb") as f:
-                return tomllib.load(f)["project"]["version"]
-        except (OSError, KeyError, tomllib.TOMLDecodeError):
-            return ""
+        return _fallback_version
 
 
 __version__ = _get_version()

--- a/sites_conformes/_version.py
+++ b/sites_conformes/_version.py
@@ -1,3 +1,7 @@
-# Overwritten by .github/workflows/publish.yml at release time from the
-# GitHub Release tag. The committed value here is the local/dev fallback.
+# Single source of truth for the version, read both at build time (setuptools
+# dynamic version, cf. pyproject.toml) and at runtime (sites_conformes/__init__.py).
+# On release, .github/workflows/publish.yml resolves the number from the GitHub
+# Release tag, writes it here, and commits this file back to main so every
+# source-based deployment (Scalingo, internal server, Docker) picks it up.
+# The value committed below is the local/dev fallback between releases.
 __version__ = "0.0.0.dev0"


### PR DESCRIPTION
## 🎯 Objectif

Corrige le mode de définition des versions avec comme source unique `__version.py` 

## 🔍 Implémentation

- Récupère la version du paquet ou à défaut la version de la dernière release qui aurait été fixé par le Github Action 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
