### PR TITLE
Amélioration du versionning et de la CI/CD

### DIFF
--- a/.github/release-config.yml
+++ b/.github/release-config.yml
@@ -1,0 +1,47 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Fonctionnalités'
+    labels:
+      - 'amélioration'
+  - title: '🐛 Corrections de bug'
+    labels:
+      - 'bug'
+      - 'sécurité'
+  - title: '📗 Documentation'
+    labels:
+      - 'documentation'
+  - title: '🔗 Montées de versions'
+    labels:
+      - 'dépendances'
+      - 'dependencies'
+      - 'python'
+      - 'javascript'
+      - 'python:uv'
+  - title: '🧰 Technique'
+    labels:
+      - 'design-system'
+      - 'composants'
+      - 'accessibilité'
+      - 'docker'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+template: |
+  ## Changements
+
+  $CHANGES

--- a/.github/workflows/_deploy-scalingo.yml
+++ b/.github/workflows/_deploy-scalingo.yml
@@ -1,0 +1,43 @@
+name: Deploy to Scalingo
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Scalingo SSH deploy key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SCALINGO_SSH_PRIVATE_KEY }}
+          SCALINGO_KNOWN_HOST: ${{ vars.SCALINGO_KNOWN_HOST || 'ssh.osc-fr1.scalingo.com' }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${SSH_PRIVATE_KEY}" > ~/.ssh/id_scalingo
+          chmod 600 ~/.ssh/id_scalingo
+          ssh-keyscan -t rsa,ecdsa,ed25519 "${SCALINGO_KNOWN_HOST}" >> ~/.ssh/known_hosts
+          {
+            echo "Host ${SCALINGO_KNOWN_HOST}"
+            echo "  IdentityFile ~/.ssh/id_scalingo"
+            echo "  IdentitiesOnly yes"
+          } >> ~/.ssh/config
+
+      - name: Push to Scalingo to trigger redeploy
+        env:
+          SCALINGO_GIT_REMOTE: ${{ vars.SCALINGO_GIT_REMOTE }}
+        run: |
+          git remote add scalingo "${SCALINGO_GIT_REMOTE}"
+          git push scalingo HEAD:master --force

--- a/.github/workflows/_release-drafter.yml
+++ b/.github/workflows/_release-drafter.yml
@@ -1,0 +1,31 @@
+name: Draft release
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Read version from __init__.py
+        id: version
+        run: |
+          VERSION=$(uv run python -c "from sites_conformes import __version__; print(__version__)")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          config-name: release-config.yml
+          version: v${{ steps.version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   ci:
     name: CI
@@ -25,24 +21,5 @@ jobs:
   release-drafter:
     name: Release drafter
     needs: deploy-staging
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Read version from __init__.py
-        id: version
-        run: |
-          VERSION=$(uv run python -c "from sites_conformes import __version__; print(__version__)")
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
-        with:
-          config-name: release-config.yml
-          version: v${{ steps.version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_release-drafter.yml
+    secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,48 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  deploy-staging:
+    name: Deploy staging
+    needs: ci
+    uses: ./.github/workflows/_deploy-scalingo.yml
+    secrets: inherit
+    with:
+      environment: staging
+
+  release-drafter:
+    name: Release drafter
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Read version from __init__.py
+        id: version
+        run: |
+          VERSION=$(uv run python -c "from sites_conformes import __version__; print(__version__)")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          config-name: release-config.yml
+          version: v${{ steps.version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,6 +1,6 @@
 name: 🎭 CI - E2E tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   # Generate the trusted visual baseline from the target branch (main). The

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,6 +1,6 @@
 name: 🔮 CI - Main checks
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1,6 +1,6 @@
 name: 🔮 CI - Quality checks
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,142 @@
+name: CI
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings_test
+      PYTHONPATH: .
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: dju
+          POSTGRES_PASSWORD: djpwd
+          POSTGRES_DB: djdb
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+      - uses: pre-commit/action@v3.0.1
+      - name: Black & ruff on all files
+        run: just quality
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings_test
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: dju
+          POSTGRES_PASSWORD: djpwd
+          POSTGRES_DB: djdb
+          POSTGRESQL_VERSION: "17"
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync --no-group dev
+      - name: Copy empty .env.test to .env
+        run: cp .env.test .env
+      - name: Collect static files
+        run: just collectstatic
+      - name: Run the unit tests
+        run: just unittest
+      - name: Deploy starter content
+        run: |
+          just init
+          uv run python manage.py create_demo_pages
+
+  migrations:
+    name: Migrations check
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings_test
+      PYTHONPATH: .
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: dju
+          POSTGRES_PASSWORD: djpwd
+          POSTGRES_DB: djdb
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.14 with uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+      - name: Install dependencies
+        run: uv sync --no-group dev
+      - name: Copy empty .env.test to .env
+        run: cp .env.test .env
+      - name: Check pending migrations
+        run: uv run django-admin makemigrations --check --dry-run --noinput
+
+  i18n:
+    name: i18n check
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings_test
+      PYTHONPATH: .
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: dju
+          POSTGRES_PASSWORD: djpwd
+          POSTGRES_DB: djdb
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync --no-group dev
+      - name: Copy empty .env.test to .env
+        run: cp .env.test .env
+      - name: Check internationalization
+        run: |
+          just makemessages
+          just compilemessages
+          git diff --exit-code sites_conformes/locale/
+          git diff --exit-code sites_conformes/*/locale/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,53 +1,21 @@
-# See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
-# for a detailed guide.
-#
-# Triggers on GitHub Release publish or manually via workflow_dispatch.
-# The release tag IS the package version: cutting a release named e.g. v4.0.0
-# publishes sites-conformes==4.0.0 to PyPI. There is no manual version bump
-# in pyproject.toml.
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to publish (e.g. 4.0.0). Ignored when triggered by a release."
-        required: false
-        type: string
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
-
-      - name: 🐍 Set up uv
+      - name: Set up uv
         uses: astral-sh/setup-uv@v5
-
-      - name: Resolve version from release tag
-        if: github.event_name == 'release'
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          VERSION="${TAG#v}"
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-
-      - name: Resolve version from manual input
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-
-      - name: Write _version.py
-        run: |
-          echo "Publishing version: ${VERSION}"
-          printf '__version__ = "%s"\n' "${VERSION}" > sites_conformes/_version.py
-
       - name: Build package
         run: uv build
-
       - name: Upload dist
         uses: actions/upload-artifact@v4
         with:
@@ -59,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: none
-      id-token: write  # required for PyPI trusted publishing
+      id-token: write
     environment: publish
     steps:
       - name: Download dist
@@ -67,7 +35,6 @@ jobs:
         with:
           name: dist
           path: dist
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,6 @@
 # The release tag IS the package version: cutting a release named e.g. v4.0.0
 # publishes sites-conformes==4.0.0 to PyPI. There is no manual version bump
 # in pyproject.toml.
-#
-# The version lives in sites_conformes/_version.py (single source of truth for
-# both the PyPI build and the runtime). On release we (1) build & publish the
-# wheel with that version, and (2) commit the bumped _version.py back to main so
-# that every source-based deployment (Scalingo, an internal server, the Docker
-# image built from the repo) picks up the right number without any extra wiring.
 name: Publish to PyPI
 
 on:
@@ -24,45 +18,6 @@ on:
         type: string
 
 jobs:
-  # Commit the resolved version into _version.py on main so that source-based
-  # deployments (Scalingo, internal servers, Docker built from the repo) run the
-  # published number instead of the committed dev fallback. This is what makes
-  # the version correct "peu importe le mode de déploiement".
-  bump-version:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          # A token allowed to push to main (branch protection may require a
-          # PAT / GitHub App token rather than the default GITHUB_TOKEN).
-          token: ${{ secrets.VERSION_BUMP_TOKEN || github.token }}
-
-      - name: Resolve version from release tag
-        if: github.event_name == 'release'
-        run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-
-      - name: Resolve version from manual input
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-
-      - name: Write and commit _version.py
-        run: |
-          printf '__version__ = "%s"\n' "${VERSION}" > sites_conformes/_version.py
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add sites_conformes/_version.py
-          if git diff --staged --quiet; then
-            echo "Version already at ${VERSION}, nothing to commit."
-          else
-            git commit -m "chore: set version to ${VERSION}"
-            git push origin main
-          fi
-
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit
+
+  sync-production:
+    name: Sync production branch
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push tag to production branch
+        run: git push origin "${{ github.event.release.tag_name }}":production --force

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,25 +1,18 @@
 # Configuration file for the Sphinx documentation builder.
 
-import tomllib
+import sys
 from pathlib import Path
 
 project = "sites-conformes"
 copyright = "2025, DINUM"
 author = "DINUM"
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-# Read the package version from sites_conformes/pyproject.toml so the doc
-# header never drifts out of sync with the published package.
-def _read_package_version() -> str:
-    pyproject = Path(__file__).resolve().parent.parent / "sites_conformes" / "pyproject.toml"
-    try:
-        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-        return data.get("project", {}).get("version", "unknown")
-    except Exception:
-        return "unknown"
-
-
-release = _read_package_version()
+try:
+    from sites_conformes import __version__ as release
+except Exception:
+    release = "unknown"
 
 extensions = [
     "sphinx_wagtail_theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [project]
 name = "sites-conformes"
-# Version is driven by the GitHub Release tag at publish time. See
-# .github/workflows/publish.yml, which writes sites_conformes/_version.py
-# from github.event.release.tag_name (stripped of a leading "v").
-# The committed _version.py value is the local/dev fallback.
+# Version is read from sites_conformes.__version__, which is derived from
+# the VERSION tuple in sites_conformes/__init__.py (following Wagtail's pattern).
 dynamic = ["version"]
 description = "Gestionnaire de contenu permettant de créer et gérer un site internet basé sur le Système de design de l’État, accessible et responsive"
 authors = [
@@ -62,7 +60,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
-version = { attr = "sites_conformes._version.__version__" }
+version = { attr = "sites_conformes.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/sites_conformes/__init__.py
+++ b/sites_conformes/__init__.py
@@ -1,28 +1,9 @@
-import tomllib
-from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
+from wagtail.utils.version import get_version
 
 default_app_config = "sites_conformes.apps.SitesConformesAppConfig"
 
+# major.minor.patch.release.number
+# release must be one of alpha, beta, rc, or final
+VERSION = (4, 0, 0, "final", 0)
 
-def _get_version() -> str:
-    """Numéro de version, avec pyproject.toml comme source unique de vérité.
-
-    On le lit de deux façons complémentaires selon le mode de déploiement :
-    1. via les métadonnées du paquet quand il a été installé (ex. `pip install`) ;
-    2. sinon en lisant directement `pyproject.toml`, pour les instances qui tournent
-       depuis une simple copie du dépôt (cas courant ici) où le paquet n'est pas installé.
-    Retourne une chaîne vide si aucune des deux méthodes n'aboutit ; le reste du code gère ce cas.
-    """
-    try:
-        return version("sites-conformes")
-    except PackageNotFoundError:
-        try:
-            pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
-            with pyproject.open("rb") as f:
-                return tomllib.load(f)["project"]["version"]
-        except (OSError, KeyError, tomllib.TOMLDecodeError):
-            return ""
-
-
-__version__ = _get_version()
+__version__ = get_version(VERSION)

--- a/sites_conformes/__init__.py
+++ b/sites_conformes/__init__.py
@@ -1,24 +1,28 @@
+import tomllib
 from importlib.metadata import PackageNotFoundError, version
-
-from ._version import __version__ as _fallback_version
+from pathlib import Path
 
 default_app_config = "sites_conformes.apps.SitesConformesAppConfig"
 
 
 def _get_version() -> str:
-    """Numéro de version, avec `_version.py` comme source unique de vérité.
+    """Numéro de version, avec pyproject.toml comme source unique de vérité.
 
     On le lit de deux façons complémentaires selon le mode de déploiement :
     1. via les métadonnées du paquet quand il a été installé (ex. `pip install`) ;
-    2. sinon en retombant sur `sites_conformes._version.__version__`, pour les instances
-       qui tournent depuis une simple copie du dépôt (cas courant ici) où le paquet n'est
-       pas installé. C'est la même valeur que celle utilisée par setuptools au build
-       (cf. `[tool.setuptools.dynamic]` dans `pyproject.toml`).
+    2. sinon en lisant directement `pyproject.toml`, pour les instances qui tournent
+       depuis une simple copie du dépôt (cas courant ici) où le paquet n'est pas installé.
+    Retourne une chaîne vide si aucune des deux méthodes n'aboutit ; le reste du code gère ce cas.
     """
     try:
         return version("sites-conformes")
     except PackageNotFoundError:
-        return _fallback_version
+        try:
+            pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+            with pyproject.open("rb") as f:
+                return tomllib.load(f)["project"]["version"]
+        except (OSError, KeyError, tomllib.TOMLDecodeError):
+            return ""
 
 
 __version__ = _get_version()

--- a/sites_conformes/_version.py
+++ b/sites_conformes/_version.py
@@ -1,7 +1,3 @@
-# Single source of truth for the version, read both at build time (setuptools
-# dynamic version, cf. pyproject.toml) and at runtime (sites_conformes/__init__.py).
-# On release, .github/workflows/publish.yml resolves the number from the GitHub
-# Release tag, writes it here, and commits this file back to main so every
-# source-based deployment (Scalingo, internal server, Docker) picks it up.
-# The value committed below is the local/dev fallback between releases.
+# Overwritten by .github/workflows/publish.yml at release time from the
+# GitHub Release tag. The committed value here is the local/dev fallback.
 __version__ = "0.0.0.dev0"

--- a/sites_conformes/_version.py
+++ b/sites_conformes/_version.py
@@ -1,3 +1,0 @@
-# Overwritten by .github/workflows/publish.yml at release time from the
-# GitHub Release tag. The committed value here is the local/dev fallback.
-__version__ = "0.0.0.dev0"


### PR DESCRIPTION
## 🎯 Objectif

Corrige la définition de version (revert de #557) et restructure les workflows CI/CD pour une séparation claire des responsabilités : chaque job (checks, déploiement, publication, tag) vit dans son propre workflow réutilisable, orchestré par un point d'entrée unique par déclencheur.

`__init__.py` redevient l'unique source de vérité pour la version (pattern Wagtail : tuple `VERSION`, `wagtail.utils.version.get_version` réutilisé directement plutôt que réimplémenté). Plus aucun job CI ne pousse de commit sur `main`.

## 🔍 Implémentation

- **Revert de #557** : suppression de `sites_conformes/_version.py` et du job qui committait sur `main` depuis la CI. `sites_conformes/__init__.py` redevient la source unique (tuple `VERSION`), lu par `pyproject.toml` (`[tool.setuptools.dynamic]`) et par `docs/conf.py`.
- **`__init__.py`** : réutilise `wagtail.utils.version.get_version` (dépendance déjà présente) au lieu d'une réimplémentation locale de la même logique.
- **Découpage des workflows par responsabilité**, chacun réutilisable via `workflow_call` :
  - `ci.yml` — quality, tests unitaires, migrations, i18n
  - `_deploy-scalingo.yml` — déploiement d'un environnement donné
  - `_release-drafter.yml` — rédaction du brouillon de release à partir de la version courante
  - `publish.yml` — build + publication PyPI
  - `cd.yml` — orchestrateur sur push vers `main` : `ci` → `deploy-staging` → `release-drafter`
  - `release.yml` — orchestrateur sur publication d'une release : `publish` → `sync-production` (tag poussé sur la branche `production`)

## ⚠️ Informations supplémentaires

```mermaid
flowchart TD
    subgraph push["Push sur main"]
        A[cd.yml] --> B[ci.yml<br/>quality / tests / migrations / i18n]
        B --> C[_deploy-scalingo.yml<br/>staging]
        C --> D[_release-drafter.yml<br/>brouillon de release]
    end

    H["Publication manuelle<br/>du brouillon (humain)"]

    subgraph rel["Publication d'une release GitHub"]
        E[release.yml] --> F[publish.yml<br/>build + PyPI]
        F --> G[sync-production<br/>tag poussé sur production]
    end

    D -.->|version lue depuis| I["sites_conformes/__init__.py<br/>(source unique de vérité)"]
    F -.->|version lue depuis| I
    D --> H
    H -->|déclenche l'event<br/>release: published| E
```

- `sites_conformes/__init__.py` est désormais la seule source de vérité pour la version, lue à la fois par `pyproject.toml` (build du paquet) et par les workflows (`_release-drafter.yml`, `publish.yml`).
- Point d'attention non résolu dans cette PR : la version (`VERSION` dans `__init__.py`) reste à bumper manuellement, sans vérification CI qu'elle a bien été incrémentée avant merge sur `main`.
- Autre point d'attention : `sync-production` fait un `push --force` systématique du tag vers `production` sans vérification de divergence préalable.

## 🏕 Amélioration continue

- Les anciens workflows `ci-main.yml` / `ci-quality.yml` / `ci-check-migrations.yml` / `ci-check-i18n.yml` (déclenchés sur `pull_request`) coexistent avec le nouveau `ci.yml` (déclenché sur push vers `main` via `cd.yml`), avec une matrice de tests différente. À terme, il faudrait soit fusionner les deux, soit clarifier pourquoi ils diffèrent.

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran, si pertinent_
