### PR TITLE
Corrige les templates des erreurs 500 et 404

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -100,19 +100,25 @@ jobs:
           name: regression-screenshots
           path: ${{ env.SCREENSHOTS_BASE_PATH }}
 
-      # Baseline mode: run the full suite and (re)generate every snapshot, then
-      # upload them as the trusted baseline. This step never fails on a visual
-      # diff — that is the point of a baseline.
-      - name: Run Playwright tests (full suite + generate snapshots)
+      # Baseline mode: render only the @regression tests and (re)generate their
+      # snapshots, then upload as the trusted baseline. Functional (non-
+      # @regression) tests are skipped here — main doesn't have the PR's app
+      # changes yet, so asserting behavior against it is meaningless and can
+      # spuriously fail (e.g. a bugfix's new test failing against old main).
+      # This step never fails on a visual diff — that is the point of a
+      # baseline.
+      - name: Run Playwright tests (generate regression snapshots)
         if: ${{ !inputs.compare }}
-        run: npx playwright test --update-snapshots
+        run: npx playwright test --update-snapshots --grep=@regression
 
-      # Compare mode: render only the @regression tests and assert each one
-      # matches the baseline downloaded above. NO --update-snapshots here, so a
-      # visual diff makes this step (and the job) fail.
-      - name: Run Playwright tests (regression comparison only)
+      # Compare mode: run the full suite against the PR branch. Functional
+      # tests execute for real and assert behavior on the new code;
+      # @regression tests additionally assert their screenshot against the
+      # baseline downloaded above (see fixtures.ts). NO --update-snapshots
+      # here, so a visual diff makes this step (and the job) fail.
+      - name: Run Playwright tests (full suite)
         if: inputs.compare
-        run: npx playwright test --grep=@regression
+        run: npx playwright test
 
       - name: Upload baseline screenshots
         if: ${{ !inputs.compare }}

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -5,9 +5,11 @@ on: [push, pull_request]
 jobs:
   # Generate the trusted visual baseline from the target branch (main). The
   # reusable workflow overlays *this* branch's e2e/ + playwright config onto the
-  # main checkout, so both jobs run identical test definitions — only the
-  # application code differs. The screenshots produced here are uploaded as the
-  # `regression-screenshots` artifact.
+  # main checkout, so both jobs run identical @regression test definitions —
+  # only the application code differs. Only @regression tests run here (see
+  # _e2e.yml); other functional tests are skipped since main may not yet have
+  # the app changes they assert on. The screenshots produced here are
+  # uploaded as the `regression-screenshots` artifact.
   baseline:
     name: Baseline (main)
     uses: ./.github/workflows/_e2e.yml
@@ -17,8 +19,9 @@ jobs:
     permissions:
       contents: read
 
-  # Render the PR branch and compare each @regression screenshot against the
-  # baseline. Any visual diff fails this job.
+  # Render the full suite against the PR branch: functional tests assert
+  # behavior for real, and each @regression test also compares its screenshot
+  # against the baseline. Any test failure or visual diff fails this job.
   compare:
     name: Compare (current branch)
     needs: baseline

--- a/config/urls.py
+++ b/config/urls.py
@@ -58,3 +58,6 @@ urlpatterns += i18n_patterns(
     path("", include("sites_conformes.core.urls")),
     prefix_default_language=False,
 )
+
+handler404 = partial(page_not_found, template_name="sites_conformes_core/404.html")
+handler500 = partial(server_error, template_name="sites_conformes_core/500.html")

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,6 +14,9 @@ from wagtail.documents import urls as wagtaildocs_urls
 from config.api import api_router
 from sites_conformes.proconnect import urls as oidc_urls
 
+TEMPLATE_404 = "sites_conformes_core/404.html"
+TEMPLATE_500 = "sites_conformes_core/500.html"
+
 urlpatterns = [
     path("sitemap.xml", sitemap, name="xml_sitemap"),
     path(settings.WAGTAILADMIN_PATH, include(wagtailadmin_urls)),
@@ -47,9 +50,9 @@ if settings.DEBUG or settings.TESTING:
         path(
             "404/",
             page_not_found,
-            kwargs={"exception": Exception("Page not Found"), "template_name": "sites_conformes_core/404.html"},
+            kwargs={"exception": Exception("Page not Found"), "template_name": TEMPLATE_404},
         ),
-        path("500/", partial(server_error, template_name="sites_conformes_core/500.html")),
+        path("500/", partial(server_error, template_name=TEMPLATE_500)),
         prefix_default_language=False,
     )
 
@@ -59,5 +62,5 @@ urlpatterns += i18n_patterns(
     prefix_default_language=False,
 )
 
-handler404 = partial(page_not_found, template_name="sites_conformes_core/404.html")
-handler500 = partial(server_error, template_name="sites_conformes_core/500.html")
+handler404 = partial(page_not_found, template_name=TEMPLATE_404)
+handler500 = partial(server_error, template_name=TEMPLATE_500)

--- a/e2e/errors.spec.ts
+++ b/e2e/errors.spec.ts
@@ -1,0 +1,10 @@
+import { expect } from "@playwright/test"
+import { test } from "./fixtures"
+
+test.describe("Pages d'erreur", () => {
+  test("une URL inconnue affiche la page 404", async ({ page }) => {
+    const response = await page.goto("/coucou")
+    expect(response?.status()).toBe(404)
+    await expect(page.getByRole("heading", { name: "Page non trouvée" })).toBeVisible()
+  })
+})

--- a/e2e/errors.spec.ts
+++ b/e2e/errors.spec.ts
@@ -5,6 +5,6 @@ test.describe("Pages d'erreur", () => {
   test("une URL inconnue affiche la page 404", async ({ page }) => {
     const response = await page.goto("/coucou")
     expect(response?.status()).toBe(404)
-    await expect(page.getByRole("heading", { name: "Page non trouvée" })).toBeVisible()
+    await expect(page.locator("[role=banner].fr-header")).toBeVisible()
   })
 })


### PR DESCRIPTION
## 🎯 Objectif

Suite à la packagification les templates `404.html` et `500.html` ont été namespacés et plus récupérés par django automatiquement

## 🔍 Implémentation

Définition dans le router de handler404 et handler500 cf documentation https://docs.djangoproject.com/fr/6.0/ref/urls/#django.conf.urls.handler404 

## ⚠️ Informations supplémentaires

ajout d'une test e2e et inversion de la logique comparaison / full run qui avait été mal concu initialement
