### PR TITLE
Corrige l'erreur de la CI  sur l'internationalisation 

### DIFF
--- a/.github/workflows/ci-check-i18n.yml
+++ b/.github/workflows/ci-check-i18n.yml
@@ -50,6 +50,11 @@ jobs:
       - name: 🌍 Check internationalization
         run: |
           just makemessages
+          # Compile to validate the .po files parse, then discard the recompiled
+          # .mo binaries: their layout (hash-table sizing) depends on the local
+          # gettext version, so they are not a reliable diff target across
+          # environments. Only the .po source files are checked.
           just compilemessages
-          git diff --exit-code sites_conformes/locale/
-          git diff --exit-code sites_conformes/*/locale/
+          git checkout -- 'sites_conformes/locale/*.mo' 'sites_conformes/*/locale/*.mo'
+          git diff --exit-code -- 'sites_conformes/locale/*.po'
+          git diff --exit-code -- 'sites_conformes/*/locale/*.po'

--- a/.github/workflows/ci-check-i18n.yml
+++ b/.github/workflows/ci-check-i18n.yml
@@ -50,11 +50,6 @@ jobs:
       - name: 🌍 Check internationalization
         run: |
           just makemessages
-          # Compile to validate the .po files parse, then discard the recompiled
-          # .mo binaries: their layout (hash-table sizing) depends on the local
-          # gettext version, so they are not a reliable diff target across
-          # environments. Only the .po source files are checked.
           just compilemessages
-          git checkout -- 'sites_conformes/locale/*.mo' 'sites_conformes/*/locale/*.mo'
-          git diff --exit-code -- 'sites_conformes/locale/*.po'
-          git diff --exit-code -- 'sites_conformes/*/locale/*.po'
+          git diff --exit-code sites_conformes/locale/
+          git diff --exit-code sites_conformes/*/locale/

--- a/justfile
+++ b/justfile
@@ -60,8 +60,8 @@ alias messages := makemessages
 # Update the translation files
 [group('Internationalization')]
 makemessages:
-    {{docker_cmd}} {{uv_run}} python manage.py makemessages -l fr --ignore=manage.py --ignore=config --ignore=medias --ignore=__init__.py --ignore=setup.py --ignore=staticfiles  --no-location
-    {{docker_cmd}} {{uv_run}} python manage.py makemessages -d djangojs -l fr --ignore=config --ignore=medias --ignore=staticfiles --no-location
+    {{docker_cmd}} {{uv_run}} python manage.py makemessages -l fr --ignore=manage.py --ignore=config --ignore=medias --ignore=__init__.py --ignore=setup.py --ignore=staticfiles --ignore=docs --no-location
+    {{docker_cmd}} {{uv_run}} python manage.py makemessages -d djangojs -l fr --ignore=config --ignore=medias --ignore=staticfiles --ignore=docs --no-location
 
 alias mm:= makemigrations
 makemigrations app="":


### PR DESCRIPTION
## 🎯 Objectif

Corrige les erreurs de CI sur les fichiers de traductions. 
L'erreur provient de l'ajout de Sphinx qui ajoute des fichiers en .js qui entre dans le scope de la traduction. 

## 🔍 Implémentation

-  ignore les changements de /docs 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
